### PR TITLE
KiD refactor

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,7 +85,7 @@ steps:
 
       - label: ":crystal_ball: Experiments: non equil (fixed rhod and T) + VarTimeScaleAcnv "
         command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=NonEquilibriumMoisture --prognostic_vars=RhodTQ --precipitation_choice=Precipitation1M --rain_formation_scheme_choice VarTimeScaleAcnv --prescribed_Nd 1e8"
-        artifact_paths: "test/experiments/KiD_driver/Output_EquilibriumMoisture_RhodTQ_Precipitation1M_VarTimeScaleAcnv/figures/*"
+        artifact_paths: "test/experiments/KiD_driver/Output_NonEquilibriumMoisture_RhodTQ_Precipitation1M_VarTimeScaleAcnv/figures/*"
 
       - label: ":crystal_ball: Experiments: equil (fixed rhod and T) + SB2006 "
         command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=EquilibriumMoisture --prognostic_vars=RhodTQ --precipitation_choice=Precipitation2M --rain_formation_scheme_choice SB2006 --sedimentation_scheme_choice SB2006 --prescribed_Nd 1e8"

--- a/src/BoxModel/ode_utils.jl
+++ b/src/BoxModel/ode_utils.jl
@@ -11,17 +11,12 @@ function make_rhs_function(ms::CO.AbstractMoistureStyle, ps::CO.AbstractPrecipit
 
     function rhs!(dY, Y, aux, t)
 
-        for eq_style in [ms, ps]
-            CO.zero_tendencies!(eq_style, dY, Y, aux, t)
-        end
+        CO.zero_tendencies!(dY)
 
-        CO.precompute_aux_thermo!(ms, dY, Y, aux, t)
-        CO.precompute_aux_precip!(ps, dY, Y, aux, t)
+        CO.precompute_aux_thermo!(ms, Y, aux)
+        CO.precompute_aux_precip!(ps, Y, aux)
 
-        for eq_style in [ms, ps]
-            CO.sources_tendency!(eq_style, dY, Y, aux, t)
-        end
-
+        CO.precip_sources_tendency!(ms, ps, dY, Y, aux, t)
     end
     return rhs!
 end

--- a/src/CalibrateCMP/KiDUtils.jl
+++ b/src/CalibrateCMP/KiDUtils.jl
@@ -110,6 +110,7 @@ function run_KiD(u::Array{FT, 1}, u_names::Array{String, 1}, model_settings::Dic
         nothing,
         face_space,
         moisture,
+        precip,
     )
     ode_rhs! = KD.make_rhs_function(moisture, precip)
     problem = ODE.ODEProblem(ode_rhs!, Y, (model_settings["t_ini"], model_settings["t_end"]), aux)
@@ -235,7 +236,7 @@ function ODEsolution2Gvector(ODEsol, aux, precip, variables, filter)
     for i in 1:_nt_filtered
         _single_filtered_cell_data = zeros(_nz * _nvar, _nt_per_filtered_cell)
         for j in 1:_nt_per_filtered_cell
-            u = ODEsol[(i - 1) * _nt_per_filtered_cell + j]
+            u = ODEsol[:, (i - 1) * _nt_per_filtered_cell + j]
             for (k, var) in enumerate(variables)
                 _single_filtered_cell_data[((k - 1) * _nz + 1):(k * _nz), j] =
                     CO.get_variable_data_from_ODE(u, aux, precip, var)

--- a/src/Common/equation_types.jl
+++ b/src/Common/equation_types.jl
@@ -14,11 +14,13 @@ export EquilibriumMoisture_ρθq
 export EquilibriumMoisture_ρdTq
 export NonEquilibriumMoisture_ρθq
 export NonEquilibriumMoisture_ρdTq
+export MoistureP3
 
 export NoPrecipitation
 export Precipitation0M
 export Precipitation1M
 export Precipitation2M
+export PrecipitationP3
 
 abstract type AbstractStyle end
 Base.broadcastable(x::AbstractStyle) = Ref(x)
@@ -39,6 +41,7 @@ struct NonEquilibriumMoisture_ρdTq{CL, IC} <: NonEquilibriumMoisture
     liquid::CL
     ice::IC
 end
+struct MoistureP3 <: AbstractMoistureStyle end
 
 struct NoPrecipitation <: AbstractPrecipitationStyle end
 struct Precipitation0M{P0M} <: AbstractPrecipitationStyle
@@ -56,4 +59,9 @@ end
 struct Precipitation2M{PT, ST} <: AbstractPrecipitationStyle
     rain_formation::PT
     sedimentation::ST
+end
+struct PrecipitationP3{PT, ST, P3} <: AbstractPrecipitationStyle
+    rain_formation::PT
+    sedimentation::ST
+    p3_parameters::P3
 end

--- a/src/Common/helper_functions.jl
+++ b/src/Common/helper_functions.jl
@@ -82,7 +82,7 @@ end
 """
 function get_variable_data_from_ODE(u, aux, precip, var::String)
 
-    ρ = parent(aux.moisture_variables.ρ_dry)[:] .+ parent(u.ρq_tot)[:]
+    ρ = parent(aux.thermo_variables.ρ_dry)[:] .+ parent(u.ρq_tot)[:]
 
     if var == "qt"
         output = parent(u.ρq_tot) ./ ρ

--- a/src/Common/initial_condition.jl
+++ b/src/Common/initial_condition.jl
@@ -120,7 +120,6 @@ function initial_condition_1d(
     # assuming no cloud condensate in the initial profile
     θ_liq_ice::FT = θ_std # TODO - compute this based on TS
     q_tot::FT = q_vap
-    ρq_tot::FT = q_tot * ρ
 
     θ_dry::FT = SDM_θ_dry(thermo_params, θ_std, q_vap)
     T::FT = SDM_T(thermo_params, θ_dry, ρ_dry)
@@ -128,37 +127,28 @@ function initial_condition_1d(
     ts = TD.PhaseEquil_ρTq(thermo_params, ρ, T, q_tot)
     p::FT = TD.air_pressure(thermo_params, ts)
 
-    q_liq::FT = TD.liquid_specific_humidity(thermo_params, ts)
-    q_ice::FT = TD.ice_specific_humidity(thermo_params, ts)
-    ρq_liq::FT = q_liq * ρ
-    ρq_ice::FT = q_ice * ρ
-
-    q_rai::FT = FT(0.0)
-    q_sno::FT = FT(0.0)
-    ρq_rai::FT = q_rai * ρ
-    ρq_sno::FT = q_sno * ρ
-    N_liq::FT = FT(0)
-    N_rai::FT = FT(0)
     N_aer_0::FT = common_params.prescribed_Nd * ρ_dry / ρ_SDP
     N_aer::FT = N_aer_0
 
-    S_ql_moisture::FT = FT(0.0)
-    S_qi_moisture::FT = FT(0.0)
+    q_liq::FT = FT(0) #TD.liquid_specific_humidity(thermo_params, ts)
+    q_ice::FT = FT(0) #TD.ice_specific_humidity(thermo_params, ts)
+    q_rai::FT = FT(0)
+    q_sno::FT = FT(0)
+    q_rim::FT = FT(0)
+    B_rim::FT = FT(0)
 
-    S_qt_precip::FT = FT(0.0)
-    S_ql_precip::FT = FT(0.0)
-    S_qi_precip::FT = FT(0.0)
-    S_qr_precip::FT = FT(0.0)
-    S_qs_precip::FT = FT(0.0)
-    S_Nl_precip::FT = FT(0)
-    S_Nr_precip::FT = FT(0)
+    ρq_tot::FT = q_tot * ρ
+    ρq_liq::FT = q_liq * ρ
+    ρq_ice::FT = q_ice * ρ
+    ρq_rai::FT = q_rai * ρ
+    ρq_sno::FT = q_sno * ρ
+    ρq_rim::FT = q_rim * ρ
 
-    S_Na_activation::FT = FT(0)
-    S_Nl_activation::FT = FT(0)
+    N_liq::FT = FT(0)
+    N_ice::FT = FT(0)
+    N_rai::FT = FT(0)
 
-    term_vel_rai::FT = FT(0)
-    term_vel_sno::FT = FT(0)
-    term_vel_N_rai::FT = FT(0)
+    zero::FT = FT(0)
 
     return (;
         ρ,
@@ -177,24 +167,14 @@ function initial_condition_1d(
         q_ice,
         q_rai,
         q_sno,
+        q_rim,
+        B_rim,
         N_liq,
+        N_ice,
         N_rai,
         N_aer,
         N_aer_0,
-        S_ql_moisture,
-        S_qi_moisture,
-        S_qt_precip,
-        S_ql_precip,
-        S_qi_precip,
-        S_qr_precip,
-        S_qs_precip,
-        S_Nl_precip,
-        S_Nr_precip,
-        S_Na_activation,
-        S_Nl_activation,
-        term_vel_rai,
-        term_vel_sno,
-        term_vel_N_rai,
+        zero,
     )
 end
 
@@ -241,8 +221,8 @@ function initial_condition(
     num_ratio = SF.gamma_inc(thrshld, k)[2]
     N_liq::FT = num_ratio * Nd
     N_rai::FT = Nd - N_liq
-    N_aer_0::FT = FT(0.0)
-    N_aer::FT = FT(0.0)
+    N_aer_0::FT = FT(0)
+    N_aer::FT = FT(0)
 
     T::FT = FT(300)
     q = TD.PhasePartition(q_tot, q_liq, q_ice)
@@ -251,23 +231,7 @@ function initial_condition(
     θ_liq_ice = TD.liquid_ice_pottemp(thermo_params, ts)
     θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
 
-    S_ql_moisture::FT = FT(0.0)
-    S_qi_moisture::FT = FT(0.0)
-
-    S_qt_precip::FT = FT(0.0)
-    S_ql_precip::FT = FT(0.0)
-    S_qi_precip::FT = FT(0.0)
-    S_qr_precip::FT = FT(0.0)
-    S_qs_precip::FT = FT(0.0)
-    S_Nl_precip::FT = FT(0)
-    S_Nr_precip::FT = FT(0)
-
-    S_Na_activation::FT = FT(0)
-    S_Nl_activation::FT = FT(0)
-
-    term_vel_rai::FT = FT(0)
-    term_vel_sno::FT = FT(0)
-    term_vel_N_rai::FT = FT(0)
+    zero::FT = FT(0)
 
     return (;
         ρ,
@@ -290,19 +254,6 @@ function initial_condition(
         N_rai,
         N_aer,
         N_aer_0,
-        S_ql_moisture,
-        S_qi_moisture,
-        S_qt_precip,
-        S_ql_precip,
-        S_qi_precip,
-        S_qr_precip,
-        S_qs_precip,
-        S_Nl_precip,
-        S_Nr_precip,
-        S_Na_activation,
-        S_Nl_activation,
-        term_vel_rai,
-        term_vel_sno,
-        term_vel_N_rai,
+        zero,
     )
 end

--- a/src/Common/netcdf_io.jl
+++ b/src/Common/netcdf_io.jl
@@ -92,7 +92,7 @@ function simulation_output(aux, t::FT) where {FT <: Real}
         @inbounds ts_t[end + 1] = t::FT
 
         # write profiles
-        for field in (aux.moisture_variables, aux.precip_variables)
+        for field in (aux.thermo_variables, aux.microph_variables)
             for var in keys(Stats.output_profiles)
                 if var in propertynames(field)
                     prop = getproperty(field, var)
@@ -110,7 +110,7 @@ function simulation_output(aux, t::FT) where {FT <: Real}
         end
         # write timeseries
         ncdf_var = NC.cfvariable(ds.group["timeseries"], "ql_max", _parentname = nothing)
-        @inbounds ncdf_var[end] = maximum(aux.moisture_variables.q_liq)
+        @inbounds ncdf_var[end] = maximum(aux.microph_variables.q_liq)
 
         # close the NC dataset
     end

--- a/src/Common/ode_utils.jl
+++ b/src/Common/ode_utils.jl
@@ -53,7 +53,6 @@ function initialise_state(::EquilibriumMoisture, ::Precipitation2M, initial_prof
     return CC.Fields.FieldVector(;
         ρq_tot = initial_profiles.ρq_tot,
         ρq_rai = initial_profiles.ρq_rai,
-        ρq_sno = initial_profiles.ρq_sno,
         N_liq = initial_profiles.N_liq,
         N_rai = initial_profiles.N_rai,
         N_aer = initial_profiles.N_aer,
@@ -65,9 +64,22 @@ function initialise_state(::NonEquilibriumMoisture, ::Precipitation2M, initial_p
         ρq_liq = initial_profiles.ρq_liq,
         ρq_ice = initial_profiles.ρq_ice,
         ρq_rai = initial_profiles.ρq_rai,
-        ρq_sno = initial_profiles.ρq_sno,
         N_liq = initial_profiles.N_liq,
         N_rai = initial_profiles.N_rai,
+        N_aer = initial_profiles.N_aer,
+    )
+end
+function initialise_state(::MoistureP3, ::PrecipitationP3, initial_profiles)
+    return CC.Fields.FieldVector(;
+        ρq_tot = initial_profiles.ρq_tot,
+        ρq_liq = initial_profiles.ρq_liq,
+        ρq_rai = initial_profiles.ρq_rai,
+        ρq_ice = initial_profiles.ρq_ice,
+        ρq_rim = initial_profiles.ρq_rim,
+        B_rim = initial_profiles.B_rim,
+        N_liq = initial_profiles.N_liq,
+        N_rai = initial_profiles.N_rai,
+        N_ice = initial_profiles.N_ice,
         N_aer = initial_profiles.N_aer,
     )
 end
@@ -77,60 +89,142 @@ end
    The auxiliary state is created as a ClimaCore FieldVector
    and passed to ODE solver via the `p` parameter of the ODEProblem.
 """
-function initialise_aux(FT, ip, common_params, thermo_params, air_params, activation_params, TS, Stats, moisture)
+function initialise_aux(
+    FT,
+    ip,
+    common_params,
+    thermo_params,
+    air_params,
+    activation_params,
+    TS,
+    Stats,
+    moisture,
+    precip,
+)
 
+    # Create a thermo state for aux
+    # Allocate the cloud_sources which is a field of containers (tuples)
+    # for storing non-equilibrium cloud formation sources
     if moisture isa EquilibriumMoisture
         ts = @. TD.PhaseEquil_ρθq(thermo_params, ip.ρ, ip.θ_liq_ice, ip.q_tot)
+        cloud_sources = nothing
     elseif moisture isa NonEquilibriumMoisture
         q = @. TD.PhasePartition(ip.q_tot, ip.q_liq, ip.q_ice)
         ts = @. TD.PhaseNonEquil_ρθq(thermo_params, ip.ρ, ip.θ_liq_ice, q)
+
+        cloud_sources_eltype = @NamedTuple{q_liq::FT, q_ice::FT}
+        cloud_sources = @. cloud_sources_eltype(tuple(copy(ip.zero), copy(ip.zero)))
     else
         error(
             "Wrong moisture choise $moisture. The supported options are EquilibriumMoisture and NonEquilibriumMoisture",
         )
     end
 
-    return (;
-        moisture_variables = CC.Fields.FieldVector(;
-            ρ = ip.ρ,
-            ρ_dry = ip.ρ_dry,
-            p = ip.p,
-            T = ip.T,
-            θ_liq_ice = ip.θ_liq_ice,
-            θ_dry = ip.θ_dry,
+    # Allocate scratch which is a tuple of fields for storing intermediate outputs
+    scratch = (; tmp = similar(ip.q_tot), tmp2 = similar(ip.q_tot), tmp3 = similar(ip.q_tot))
+
+    # Allocate a tuple of fields for storing precomputed thermodynamic variables
+    thermo_variables =
+        (; ts = ts, ρ = ip.ρ, ρ_dry = ip.ρ_dry, p = ip.p, T = ip.T, θ_liq_ice = ip.θ_liq_ice, θ_dry = ip.θ_dry)
+
+    if precip isa Union{NoPrecipitation, Precipitation0M}
+        microph_variables = (; q_tot = ip.q_tot, q_liq = ip.q_liq, q_ice = ip.q_ice)
+        velocities = nothing
+        precip_sources_eltype = @NamedTuple{q_tot::FT, q_liq::FT, q_ice::FT}
+        precip_sources = @. precip_sources_eltype(tuple(copy(ip.zero), copy(ip.zero), copy(ip.zero)))
+    elseif precip isa Precipitation1M
+        microph_variables = (; q_tot = ip.q_tot, q_liq = ip.q_liq, q_ice = ip.q_ice, q_rai = ip.q_rai, q_sno = ip.q_sno)
+        velocities = (; term_vel_rai = copy(ip.zero), term_vel_sno = copy(ip.zero))
+        precip_sources_eltype = @NamedTuple{q_tot::FT, q_liq::FT, q_ice::FT, q_rai::FT, q_sno::FT}
+        precip_sources =
+            @. precip_sources_eltype(tuple(copy(ip.zero), copy(ip.zero), copy(ip.zero), copy(ip.zero), copy(ip.zero)))
+    elseif precip isa Precipitation2M
+        microph_variables = (;
             q_tot = ip.q_tot,
             q_liq = ip.q_liq,
             q_ice = ip.q_ice,
-            ts = ts,
-        ),
-        precip_variables = CC.Fields.FieldVector(;
             q_rai = ip.q_rai,
-            q_sno = ip.q_sno,
             N_liq = ip.N_liq,
             N_rai = ip.N_rai,
-        ),
-        aerosol_variables = CC.Fields.FieldVector(; N_aer = ip.N_aer, N_aer_0 = ip.N_aer_0),
-        activation_sources = CC.Fields.FieldVector(; S_N_aer = ip.S_Na_activation, S_N_liq = ip.S_Nl_activation),
-        moisture_sources = CC.Fields.FieldVector(; S_q_liq = ip.S_ql_moisture, S_q_ice = ip.S_qi_moisture),
-        precip_sources = CC.Fields.FieldVector(;
-            S_q_tot = ip.S_qt_precip,
-            S_q_liq = ip.S_ql_precip,
-            S_q_ice = ip.S_qi_precip,
-            S_q_rai = ip.S_qr_precip,
-            S_q_sno = ip.S_qs_precip,
-            S_N_liq = ip.S_Nl_precip,
-            S_N_rai = ip.S_Nr_precip,
-        ),
-        precip_velocities = CC.Fields.FieldVector(;
-            term_vel_rai = ip.term_vel_rai,
-            term_vel_sno = ip.term_vel_sno,
-            term_vel_N_rai = ip.term_vel_N_rai,
-        ),
-        common_params = common_params,
-        thermo_params = thermo_params,
-        air_params = air_params,
-        activation_params = activation_params,
-        Stats = Stats,
-        TS = TS,
+            N_aer = ip.N_aer,
+            N_aer_0 = ip.N_aer_0,
+        )
+        velocities = (; term_vel_N_rai = copy(ip.zero), term_vel_rai = copy(ip.zero))
+        precip_sources_eltype = @NamedTuple{q_tot::FT, q_liq::FT, q_rai::FT, N_aer::FT, N_liq::FT, N_rai::FT}
+        precip_sources = @. precip_sources_eltype(
+            tuple(copy(ip.zero), copy(ip.zero), copy(ip.zero), copy(ip.zero), copy(ip.zero), copy(ip.zero)),
+        )
+    elseif precip isa PrecipitationP3
+        microph_variables = (;
+            q_tot = ip.q_tot,
+            q_liq = ip.q_liq,
+            q_rai = ip.q_rai,
+            q_ice = ip.q_ice,
+            q_rim = ip.q_rim,
+            B_rim = ip.B_rim,
+            N_liq = ip.N_liq,
+            N_rai = ip.N_rai,
+            N_ice = ip.N_ice,
+            N_aer = ip.N_aer,
+        )
+        velocities = (;
+            term_vel_rai = copy(ip.zero),
+            term_vel_ice = copy(ip.zero),
+            term_vel_N_rai = copy(ip.zero),
+            term_vel_N_ice = copy(ip.zero),
+        )
+        precip_sources_eltype = @NamedTuple{
+            q_tot::FT,
+            q_liq::FT,
+            q_rai::FT,
+            q_ice::FT,
+            q_rim::FT,
+            N_aer::FT,
+            N_liq::FT,
+            N_rai::FT,
+            N_ice::FT,
+            B_rim::FT,
+        }
+        precip_sources = @. precip_sources_eltype(
+            tuple(
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+                copy(ip.zero),
+            ),
+        )
+
+        @assert moisture isa NonEquilibrumMoisture
+    else
+        error("Wrong precipitation choise $precip")
+    end
+
+    if precip isa Precipitation2M
+        activation_sources_eltype = @NamedTuple{N_aer::FT, N_liq::FT}
+        activation_sources = @. activation_sources_eltype(tuple(copy(ip.zero), copy(ip.zero)))
+    else
+        activation_sources = nothing
+    end
+
+    return (;
+        scratch,
+        thermo_variables,
+        microph_variables,
+        activation_sources,
+        cloud_sources,
+        precip_sources,
+        velocities,
+        common_params,
+        thermo_params,
+        air_params,
+        activation_params,
+        Stats,
+        TS,
     )
 end

--- a/src/Common/tendency.jl
+++ b/src/Common/tendency.jl
@@ -2,265 +2,294 @@
    Different components of the ODE `rhs!` function,
    depending on the moisture and precipitation types.
 """
+# some aliases to improve readability
+const PP = TD.PhasePartition
+const Lf = TD.latent_heat_fusion
+const q_vap = TD.vapor_specific_humidity
 
-"""
-    Zero out previous timestep tendencies and aux.S source terms
-"""
-@inline function zero_tendencies!(sm::AbstractMoistureStyle, dY, Y, aux, t)
-    error("zero_tendecies not implemented for a given $sm")
+# helper function to limit the tendency
+function limit(q::FT, dt::FT, S::FT, n = 1) where {FT}
+    return min(q / dt / n, S)
 end
-@inline function zero_tendencies!(sp::AbstractPrecipitationStyle, dY, Y, aux, t)
-    error("zero_tendecies not implemented for a given $sp")
-end
-@inline function zero_tendencies!(::EquilibriumMoisture, dY, Y, aux, t)
-    FT = eltype(Y.ρq_tot)
-    @. dY.ρq_tot = FT(0)
-end
-@inline function zero_tendencies!(::NonEquilibriumMoisture, dY, Y, aux, t)
-    FT = eltype(Y.ρq_tot)
-    @. dY.ρq_tot = FT(0)
-    @. dY.ρq_liq = FT(0)
-    @. dY.ρq_ice = FT(0)
-end
-@inline function zero_tendencies!(::Union{NoPrecipitation, Precipitation0M}, dY, Y, aux, t) end
-@inline function zero_tendencies!(::Precipitation1M, dY, Y, aux, t)
-    FT = eltype(Y.ρq_tot)
-    @. dY.ρq_rai = FT(0)
-    @. dY.ρq_sno = FT(0)
-end
-@inline function zero_tendencies!(::Precipitation2M, dY, Y, aux, t)
-    FT = eltype(Y.ρq_tot)
-    @. dY.ρq_rai = FT(0)
-    @. dY.ρq_sno = FT(0)
-    @. dY.N_liq = FT(0)
-    @. dY.N_rai = FT(0)
-    @. dY.N_aer = FT(0)
+
+# helper function to safely get q from state ρq
+function q_(ρq::FT, ρ::FT) where {FT}
+    return max(FT(0), ρq / ρ)
 end
 
 """
-     Helper functions for broadcasting and populating the auxiliary state
+    Zero out previous timestep tendencies
 """
-@inline function moisture_helper_vars_eq_ρθq(thermo_params, ρq_tot, ρ, θ_liq_ice)
-
-    ts = TD.PhaseEquil_ρθq(thermo_params, ρ, θ_liq_ice, ρq_tot / ρ)
-
-    q_tot = TD.total_specific_humidity(thermo_params, ts)
-    q_liq = TD.liquid_specific_humidity(thermo_params, ts)
-    q_ice = TD.ice_specific_humidity(thermo_params, ts)
-
-    ρ_dry = ρ - ρq_tot
-    p = TD.air_pressure(thermo_params, ts)
-    T = TD.air_temperature(thermo_params, ts)
-    θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
-
-    return (; ts, q_tot, q_liq, q_ice, ρ_dry, p, T, θ_dry)
+@inline function zero_tendencies!(dY)
+    @. dY = 0
+    #for el in dY
+    #    @info(el)
+    #    FT = eltype(el)
+    #    el .= (CC.RecursiveApply.rzero(FT),)
+    #end
 end
-@inline function moisture_helper_vars_eq_ρdTq(thermo_params, ρq_tot, ρ_dry, T)
 
-    ρ = ρ_dry .+ ρq_tot
-    ts = TD.PhaseEquil_ρTq(thermo_params, ρ, T, ρq_tot / ρ)
-    p = TD.air_pressure(thermo_params, ts)
-
-    q_tot = TD.total_specific_humidity(thermo_params, ts)
-    q_liq = TD.liquid_specific_humidity(thermo_params, ts)
-    q_ice = TD.ice_specific_humidity(thermo_params, ts)
-
-    θ_liq_ice = TD.liquid_ice_pottemp(thermo_params, ts)
-    θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
-
-    return (; ts, q_tot, q_liq, q_ice, ρ, p, θ_liq_ice, θ_dry)
+"""
+     Precompute the auxiliary values
+"""
+@inline function precompute_aux_thermo!(sm::AbstractMoistureStyle, Y, aux)
+    error("precompute_aux not implemented for a given $sm")
 end
-@inline function moisture_helper_vars_neq_ρθq(thermo_params, ρq_tot, ρq_liq, ρq_ice, ρ, θ_liq_ice)
+@inline function precompute_aux_thermo!(::EquilibriumMoisture_ρθq, Y, aux)
 
-    q_tot = ρq_tot / ρ
-    q_liq = ρq_liq / ρ
-    q_ice = ρq_ice / ρ
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    (; thermo_params) = aux
+    (; ts, ρ, ρ_dry, p, T, θ_dry, θ_liq_ice) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice) = aux.microph_variables
 
-    ts = TD.PhaseNonEquil_ρθq(thermo_params, ρ, θ_liq_ice, q)
+    @. ts = TD.PhaseEquil_ρθq(thermo_params, ρ, θ_liq_ice, Y.ρq_tot / ρ)
 
-    ρ_dry = ρ - ρq_tot
-    p = TD.air_pressure(thermo_params, ts)
-    T = TD.air_temperature(thermo_params, ts)
-    θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
+    @. q_tot = TD.total_specific_humidity(thermo_params, ts)
+    @. q_liq = TD.liquid_specific_humidity(thermo_params, ts)
+    @. q_ice = TD.ice_specific_humidity(thermo_params, ts)
 
-    return (; ts, q_tot, q_liq, q_ice, ρ_dry, p, T, θ_dry)
+    @. ρ_dry = ρ - Y.ρq_tot
+    @. p = TD.air_pressure(thermo_params, ts)
+    @. T = TD.air_temperature(thermo_params, ts)
+    @. θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
 end
-@inline function moisture_helper_vars_neq_ρdTq(thermo_params, ρq_tot, ρq_liq, ρq_ice, ρ_dry, T)
+@inline function precompute_aux_thermo!(::EquilibriumMoisture_ρdTq, Y, aux)
 
-    ρ = ρ_dry .+ ρq_tot
+    (; thermo_params) = aux
+    (; ts, ρ, ρ_dry, p, T, θ_dry, θ_liq_ice) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice) = aux.microph_variables
 
-    q_tot = ρq_tot / ρ
-    q_liq = ρq_liq / ρ
-    q_ice = ρq_ice / ρ
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    @. ρ = ρ_dry + Y.ρq_tot
+    @. ts = TD.PhaseEquil_ρTq(thermo_params, ρ, T, Y.ρq_tot / ρ)
+    @. p = TD.air_pressure(thermo_params, ts)
 
-    ts = TD.PhaseNonEquil_ρTq(thermo_params, ρ, T, q)
-    p = TD.air_pressure(thermo_params, ts)
+    @. q_tot = TD.total_specific_humidity(thermo_params, ts)
+    @. q_liq = TD.liquid_specific_humidity(thermo_params, ts)
+    @. q_ice = TD.ice_specific_humidity(thermo_params, ts)
 
-    θ_liq_ice = TD.liquid_ice_pottemp(thermo_params, ts)
-    θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
-
-    return (; ts, q_tot, q_liq, q_ice, ρ, p, θ_liq_ice, θ_dry)
+    @. θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
+    @. θ_liq_ice = TD.liquid_ice_pottemp(thermo_params, ts)
 end
-@inline function moisture_helper_sources(thermo_params, ne, ρ, T, q_tot, q_liq, q_ice)
+@inline function precompute_aux_thermo!(::NonEquilibriumMoisture_ρθq, Y, aux)
 
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    (; thermo_params) = aux
+    (; ts, ρ, ρ_dry, p, T, θ_dry, θ_liq_ice) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice) = aux.microph_variables
 
-    # from sat adjst
-    #ts = TD.PhaseEquil_ρθq(params, ρ, θ_liq_ice, ρq_tot / ρ)
-    ts_eq = TD.PhaseEquil_ρTq(thermo_params, ρ, T, q_tot)
-    q_eq = TD.PhasePartition(thermo_params, ts_eq)
+    @. q_tot = q_(Y.ρq_tot, ρ)
+    @. q_liq = q_(Y.ρq_liq, ρ)
+    @. q_ice = q_(Y.ρq_ice, ρ)
 
-    S_q_liq = CMNe.conv_q_vap_to_q_liq_ice(ne.liquid, q_eq, q)
-    S_q_ice = CMNe.conv_q_vap_to_q_liq_ice(ne.ice, q_eq, q)
+    @. ts = TD.PhaseNonEquil_ρθq(thermo_params, ρ, θ_liq_ice, PP(q_tot, q_liq, q_ice))
 
-    return (; S_q_liq, S_q_ice)
+    @. ρ_dry = ρ - Y.ρq_tot
+    @. p = TD.air_pressure(thermo_params, ts)
+    @. T = TD.air_temperature(thermo_params, ts)
+    @. θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
+    #TODO - should we delete this option? the potential temperature returned from ts is different than the input
+    #@. θ_liq_ice = TD.liquid_ice_pottemp(thermo_params, ts)
+    #@info("Inside the tendency, after ts", θ_liq_ice )
 end
-@inline function precip_helper_vars(ρq_rai, ρq_sno, ρ)
+@inline function precompute_aux_thermo!(::NonEquilibriumMoisture_ρdTq, Y, aux)
 
-    q_rai = ρq_rai / ρ
-    q_sno = ρq_sno / ρ
+    (; thermo_params) = aux
+    (; ts, ρ, ρ_dry, p, T, θ_dry, θ_liq_ice) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice) = aux.microph_variables
 
-    return (; q_rai, q_sno)
+    @. ρ = ρ_dry + Y.ρq_tot
+
+    @. q_tot = q_(Y.ρq_tot, ρ)
+    @. q_liq = q_(Y.ρq_liq, ρ)
+    @. q_ice = q_(Y.ρq_ice, ρ)
+
+    @. ts = TD.PhaseNonEquil_ρTq(thermo_params, ρ, T, PP(q_tot, q_liq, q_ice))
+    @. p = TD.air_pressure(thermo_params, ts)
+    @. θ_dry = TD.dry_pottemp(thermo_params, T, ρ_dry)
+    @. θ_liq_ice = TD.liquid_ice_pottemp(thermo_params, ts)
 end
-@inline function precip_helper_sources!(ps::Precipitation0M, thermo_params, ts, q_tot, q_liq, q_ice, dt)
 
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    qsat = TD.q_vap_saturation(thermo_params, ts)
-    λ = TD.liquid_fraction(thermo_params, ts)
+@inline function precompute_aux_precip!(::Union{NoPrecipitation, Precipitation0M}, Y, aux) end
+@inline function precompute_aux_precip!(ps::Precipitation1M, Y, aux)
 
-    S_qt = -min(max(0, (q.liq + q.ice) / dt), -CM0.remove_precipitation(ps.params, q, qsat))
+    FT = eltype(Y.ρq_rai)
 
-    S_q_rai = -S_qt * λ
-    S_q_sno = -S_qt * (1 - λ)
-    S_q_tot = S_qt
-    S_q_liq = S_qt * λ
-    S_q_ice = S_qt * (1 - λ)
-    #θ_liq_ice_tendency -= S_qt / Π_m / c_pm * (L_v0 * λ + L_s0 * (1 - λ))
+    (; ρ) = aux.thermo_variables
+    (; q_rai, q_sno) = aux.microph_variables
+    (; term_vel_rai, term_vel_sno) = aux.velocities
 
-    return (; S_q_tot, S_q_liq, S_q_ice, S_q_rai, S_q_sno)
+    @. q_rai = q_(Y.ρq_rai, ρ)
+    @. q_sno = q_(Y.ρq_sno, ρ)
+
+    @. term_vel_rai = CM1.terminal_velocity(ps.rain, ps.sedimentation.rain, ρ, q_rai)
+    @. term_vel_sno = CM1.terminal_velocity(ps.snow, ps.sedimentation.snow, ρ, q_sno)
 end
-@inline function precip_helper_sources!(
-    ps::Precipitation1M,
-    common_params,
-    thermo_params,
-    air_params,
-    ts,
-    q_tot,
-    q_liq,
-    q_ice,
-    q_rai,
-    q_sno,
-    T,
-    ρ,
-    dt,
-)
+@inline function precompute_aux_precip!(ps::Precipitation2M, Y, aux)
 
-    FT = eltype(q_tot)
+    FT = eltype(Y.ρq_rai)
+    sb2006 = ps.rain_formation
+    vel_scheme = ps.sedimentation
+    (; ρ) = aux.thermo_variables
+    (; q_rai, N_rai, N_liq) = aux.microph_variables
+    (; term_vel_rai, term_vel_N_rai) = aux.velocities
 
-    S_q_rai::FT = FT(0)
-    S_q_sno::FT = FT(0)
-    S_q_tot::FT = FT(0)
-    S_q_liq::FT = FT(0)
-    S_q_ice::FT = FT(0)
-    S_q_vap::FT = FT(0) # added for testing
+    @. q_rai = q_(Y.ρq_rai, ρ)
+    @. N_rai = max(FT(0), Y.N_rai)
+    @. N_liq = max(FT(0), Y.N_liq)
+
+    @. term_vel_N_rai = getindex(CM2.rain_terminal_velocity(sb2006, vel_scheme, q_rai, ρ, N_rai), 1)
+    @. term_vel_rai = getindex(CM2.rain_terminal_velocity(sb2006, vel_scheme, q_rai, ρ, N_rai), 2)
+end
+@inline function precompute_aux_precip!(ps::PrecipitationP3, Y, aux)
+
+    FT = eltype(Y.ρq_rai)
+    (; ρ) = aux.thermo_variables
+    (; q_rai, q_ice, q_rim, B_rim, N_rai, N_ice, N_liq) = aux.microph_variables
+
+    @. q_rai = q_(Y.ρq_rai, ρ)
+    @. q_ice = q_(Y.ρq_ice, ρ)
+    @. q_rim = q_(Y.ρq_rim, ρ)
+    @. B_rim = q_(Y.ρq_rim, ρ)
+    @. N_rai = max(FT(0), Y.N_rai)
+    @. N_liq = max(FT(0), Y.N_liq)
+    @. N_ice = max(FT(0), Y.N_ice)
+
+    # TODO...
+end
+
+@inline function precompute_aux_moisture_sources!(sm::AbstractMoistureStyle, aux)
+    error("precompute_aux not implemented for a given $sm")
+end
+@inline function precompute_aux_moisture_sources!(::EquilibriumMoisture, aux) end
+@inline function precompute_aux_moisture_sources!(ne::NonEquilibriumMoisture, aux)
+
+    (; thermo_params) = aux
+    (; ρ, T) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice) = aux.microph_variables
+
+    S_q_liq = aux.scratch.tmp
+    S_q_ice = aux.scratch.tmp2
+
+    # helper type and wrapper to populate the tuple with sources
+    S_eltype = eltype(aux.cloud_sources)
+    to_sources(args...) = S_eltype(tuple(args...))
+
+    @. S_q_liq = CMNe.conv_q_vap_to_q_liq_ice(
+        ne.liquid,
+        PP(thermo_params, TD.PhaseEquil_ρTq(thermo_params, ρ, T, q_tot)),
+        PP(q_tot, q_liq, q_ice),
+    )
+    @. S_q_ice = CMNe.conv_q_vap_to_q_liq_ice(
+        ne.ice,
+        PP(thermo_params, TD.PhaseEquil_ρTq(thermo_params, ρ, T, q_tot)),
+        PP(q_tot, q_liq, q_ice),
+    )
+
+    @. aux.cloud_sources = to_sources(S_q_liq, S_q_ice)
+end
+
+@inline function precompute_aux_precip_sources!(sp::AbstractPrecipitationStyle, aux)
+    error("precompute_aux not implemented for a given $sp")
+end
+@inline function precompute_aux_precip_sources!(::NoPrecipitation, aux) end
+@inline function precompute_aux_precip_sources!(ps::Precipitation0M, aux)
+
+    (; thermo_params) = aux
+    (; dt) = aux.TS
+    (; ts) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice) = aux.microph_variables
+
+    S_qt = aux.scratch.tmp
+    λ = aux.scratch.tmp2
+
+    @. λ = TD.liquid_fraction(thermo_params, ts)
+
+    @. S_qt =
+        -limit(
+            q_liq + q_ice,
+            dt,
+            -CM0.remove_precipitation(ps.params, PP(q_tot, q_liq, q_ice), TD.q_vap_saturation(thermo_params, ts)),
+        )
+
+    S_eltype = eltype(aux.precip_sources)
+    to_sources(args...) = S_eltype(tuple(args...))
+
+    @. aux.precip_sources = to_sources(S_qt, S_qt * λ, S_qt * (1 - λ))
+end
+@inline function precompute_aux_precip_sources!(ps::Precipitation1M, aux)
+
+    (; dt) = aux.TS
+    (; thermo_params, common_params, air_params) = aux
+    FT = eltype(thermo_params)
+    (; ts, ρ, T) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice, q_rai, q_sno) = aux.microph_variables
+
+    S = aux.scratch.tmp
+    α = aux.scratch.tmp2
 
     T_fr::FT = TD.Parameters.T_freeze(thermo_params)
     c_vl::FT = TD.Parameters.cv_l(thermo_params)
-    c_vm::FT = TD.cv_m(thermo_params, ts)
-    Rm::FT = TD.gas_constant_air(thermo_params, ts)
-    Lf::FT = TD.latent_heat_fusion(thermo_params, ts)
 
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    q_vap::FT = TD.vapor_specific_humidity(thermo_params, ts)
+    # helper type and wrapper to populate the tuple with sources
+    S_eltype = eltype(aux.precip_sources)
+    to_sources(args...) = S_eltype(tuple(args...))
 
+    # zero out the aux sources
+    @. aux.precip_sources = to_sources(0, 0, 0, 0, 0)
+    #TODO - figure out a better way to split between equil and non-equil sources
     if Bool(common_params.precip_sources)
-        tmp::FT = FT(0)
         rf = ps.rain_formation
-        # autoconversion liquid to rain and ice to snow
-        # TODO - can we do it in a more elegant way?
+        # autoconversion of liquid to rain
         if rf isa CMP.Acnv1M{FT}
-            tmp = CM1.conv_q_liq_to_q_rai(rf, q.liq, true)
+            @. S = -limit(q_liq, dt, CM1.conv_q_liq_to_q_rai(rf, q_liq, true))
         elseif typeof(rf) in [CMP.LD2004{FT}, CMP.VarTimescaleAcnv{FT}]
-            tmp = CM2.conv_q_liq_to_q_rai(rf, q.liq, ρ, common_params.prescribed_Nd)
+            @. S = -limit(q_liq, dt, CM2.conv_q_liq_to_q_rai(rf, q_liq, ρ, common_params.prescribed_Nd))
         elseif typeof(rf.acnv) in [CMP.AcnvKK2000{FT}, CMP.AcnvB1994{FT}, CMP.AcnvTC1980{FT}]
-            tmp = CM2.conv_q_liq_to_q_rai(rf, q.liq, ρ, common_params.prescribed_Nd)
+            @. S = -limit(q_liq, dt, CM2.conv_q_liq_to_q_rai(rf, q_liq, ρ, common_params.prescribed_Nd))
         else
             error("Unrecognized rain formation scheme")
         end
-        S_qt_rain = -min(max(FT(0), q.liq / dt), tmp)
-        S_qt_snow = -min(max(FT(0), q.ice / dt), CM1.conv_q_ice_to_q_sno(ps.ice, air_params, thermo_params, q, ρ, T))
-        S_q_rai -= S_qt_rain
-        S_q_sno -= S_qt_snow
-        S_q_tot += S_qt_rain + S_qt_snow
-        S_q_liq += S_qt_rain
-        S_q_ice += S_qt_snow
-        #θ_liq_ice_tendency -= 1 / Π_m / c_pm * (L_v0 * S_qt_rain + L_s0 * S_qt_snow)
+        @. aux.precip_sources += to_sources(S, S, 0, -S, 0)
+
+        # autoconversion of ice to snow
+        @. S =
+            -limit(q_ice, dt, CM1.conv_q_ice_to_q_sno(ps.ice, air_params, thermo_params, PP(q_tot, q_liq, q_ice), ρ, T))
+        @. aux.precip_sources += to_sources(S, 0, S, 0, -S)
 
         # accretion cloud water + rain
         if typeof(rf) in [CMP.Acnv1M{FT}, CMP.LD2004{FT}, CMP.VarTimescaleAcnv{FT}]
-            tmp = CM1.accretion(ps.liquid, ps.rain, ps.sedimentation.rain, ps.ce, q.liq, q_rai, ρ)
+            @. S = limit(q_liq, dt, CM1.accretion(ps.liquid, ps.rain, ps.sedimentation.rain, ps.ce, q_liq, q_rai, ρ))
         elseif typeof(rf.accr) in [CMP.AccrKK2000{FT}, CMP.AccrB1994{FT}]
-            tmp = CM2.accretion(rf, q.liq, q_rai, ρ)
+            @. S = limit(q_liq, dt, CM2.accretion(rf, q_liq, q_rai, ρ))
         elseif rf.accr isa CMP.AccrTC1980{FT}
-            tmp = CM2.accretion(rf, q.liq, q_rai)
+            @. S = limit(q_liq, dt, CM2.accretion(rf, q_liq, q_rai))
         else
             error("Unrecognized rain formation scheme")
         end
-        S_qr = min(max(FT(0), q.liq / dt), tmp)
-        S_q_rai += S_qr
-        S_q_tot -= S_qr
-        S_q_liq -= S_qr
-        #θ_liq_ice_tendency += S_qr / Π_m / c_pm * L_v0
+        @. aux.precip_sources += to_sources(-S, -S, 0, S, 0)
 
         # accretion cloud ice + snow
-        S_qs =
-            min(max(FT(0), q.ice / dt), CM1.accretion(ps.ice, ps.snow, ps.sedimentation.snow, ps.ce, q.ice, q_sno, ρ))
-        S_q_sno += S_qs
-        S_q_tot -= S_qs
-        S_q_ice -= S_qs
-        #θ_liq_ice_tendency += S_qs / Π_m / c_pm * L_s0
+        @. S = limit(q_ice, dt, CM1.accretion(ps.ice, ps.snow, ps.sedimentation.snow, ps.ce, q_ice, q_sno, ρ))
+        @. aux.precip_sources += to_sources(-S, 0, -S, 0, S)
 
         # sink of cloud water via accretion cloud water + snow
-        S_qt =
-            -min(
-                max(FT(0), q.liq / dt),
-                CM1.accretion(ps.liquid, ps.snow, ps.sedimentation.snow, ps.ce, q.liq, q_sno, ρ),
-            )
-        if T < T_fr # cloud droplets freeze to become snow)
-            S_q_sno -= S_qt
-            S_q_tot += S_qt
-            S_q_liq += S_qt
-            #θ_liq_ice_tendency -= S_qt / Π_m / c_pm * Lf * (1 + Rm / c_vm)
-        else # snow melts, both cloud water and snow become rain
-            α::FT = c_vl / Lf * (T - T_fr)
-            S_q_tot += S_qt
-            S_q_liq += S_qt
-            S_q_sno += S_qt * α
-            S_q_rai -= S_qt * (1 + α)
-            #θ_liq_ice_tendency += S_qt / Π_m / c_pm * (Lf * (1 + Rm / c_vm) * α - L_v0)
-        end
+        @. S = -limit(q_liq, dt, CM1.accretion(ps.liquid, ps.snow, ps.sedimentation.snow, ps.ce, q_liq, q_sno, ρ))
+        @. α = c_vl / Lf(thermo_params, ts) * (T - T_fr)
+        @. aux.precip_sources += ifelse(T < T_fr, to_sources(S, S, 0, 0, -S), to_sources(S, S, 0, -S * (1 + α), S * α))
 
         # sink of cloud ice via accretion cloud ice - rain
-        S_qt =
-            -min(max(FT(0), q.ice / dt), CM1.accretion(ps.ice, ps.rain, ps.sedimentation.rain, ps.ce, q.ice, q_rai, ρ))
+        @. S = -limit(q_ice, dt, CM1.accretion(ps.ice, ps.rain, ps.sedimentation.rain, ps.ce, q_ice, q_rai, ρ))
+        @. aux.precip_sources += to_sources(S, 0, S, 0, -S)
+
         # sink of rain via accretion cloud ice - rain
-        S_qr =
-            -min(
-                max(FT(0), q_rai / dt),
-                CM1.accretion_rain_sink(ps.rain, ps.ice, ps.sedimentation.rain, ps.ce, q.ice, q_rai, ρ),
-            )
-        S_q_tot += S_qt
-        S_q_ice += S_qt
-        S_q_rai += S_qr
-        S_q_sno += -(S_qt + S_qr)
-        #θ_liq_ice_tendency -= 1 / Π_m / c_pm * (S_qr * Lf * (1 + Rm / c_vm) + S_qt * L_s0)
+        @. S =
+            -limit(q_rai, dt, CM1.accretion_rain_sink(ps.rain, ps.ice, ps.sedimentation.rain, ps.ce, q_ice, q_rai, ρ))
+        @. aux.precip_sources += to_sources(0, 0, 0, S, -S)
 
         # accretion rain - snow
-        if T < T_fr
-            S_qs = min(
-                max(FT(0), q_rai / dt),
+        @. S = ifelse(
+            T < T_fr,
+            limit(
+                q_rai,
+                dt,
                 CM1.accretion_snow_rain(
                     ps.snow,
                     ps.rain,
@@ -271,390 +300,220 @@ end
                     q_rai,
                     ρ,
                 ),
-            )
-        else
-            S_qs =
-                -min(
-                    max(FT(0), q_sno / dt),
-                    CM1.accretion_snow_rain(
-                        ps.rain,
-                        ps.snow,
-                        ps.sedimentation.rain,
-                        ps.sedimentation.snow,
-                        ps.ce,
-                        q_rai,
-                        q_sno,
-                        ρ,
-                    ),
-                )
-        end
-        S_q_sno += S_qs
-        S_q_rai -= S_qs
-        #θ_liq_ice_tendency += S_qs * Lf / Π_m / c_vm
+            ),
+            -limit(
+                q_sno,
+                dt,
+                CM1.accretion_snow_rain(
+                    ps.rain,
+                    ps.snow,
+                    ps.sedimentation.rain,
+                    ps.sedimentation.snow,
+                    ps.ce,
+                    q_rai,
+                    q_sno,
+                    ρ,
+                ),
+            ),
+        )
+        @. aux.precip_sources += to_sources(0, 0, 0, -S, S)
     end
 
     if Bool(common_params.precip_sinks)
         # evaporation
-        S_qr =
-            -min(
-                max(FT(0), q_rai / dt),
-                -CM1.evaporation_sublimation(ps.rain, ps.sedimentation.rain, air_params, thermo_params, q, q_rai, ρ, T),
+        @. S =
+            -limit(
+                q_rai,
+                dt,
+                -CM1.evaporation_sublimation(
+                    ps.rain,
+                    ps.sedimentation.rain,
+                    air_params,
+                    thermo_params,
+                    PP(q_tot, q_liq, q_ice),
+                    q_rai,
+                    ρ,
+                    T,
+                ),
             )
-        S_q_rai += S_qr
-        S_q_tot -= S_qr
-        S_q_vap -= S_qr
+        @. aux.precip_sources += to_sources(-S, 0, 0, S, 0)
 
         # melting
-        S_qs =
-            -min(
-                max(FT(0), q_sno / dt),
-                CM1.snow_melt(ps.snow, ps.sedimentation.snow, air_params, thermo_params, q_sno, ρ, T),
-            )
-        S_q_rai -= S_qs
-        S_q_sno += S_qs
+        @. S = -limit(q_sno, dt, CM1.snow_melt(ps.snow, ps.sedimentation.snow, air_params, thermo_params, q_sno, ρ, T))
+        @. aux.precip_sources += to_sources(0, 0, 0, -S, S)
 
         # deposition, sublimation
-        tmp = CM1.evaporation_sublimation(ps.snow, ps.sedimentation.snow, air_params, thermo_params, q, q_sno, ρ, T)
-        if tmp > 0
-            S_qs = min(max(FT(0), q_vap / dt), tmp)
-        else
-            S_qs = -min(max(FT(0), q_sno / dt), -tmp)
-        end
-        S_q_sno += S_qs
-        S_q_tot -= S_qs
-        S_q_vap -= S_qs
-
-        #θ_liq_ice_tendency +=
-        #    1 / Π_m / c_pm * (
-        #        S_qr_evap * (L_v - R_v * T) * (1 + R_m / c_vm) +
-        #        S_qs_sub_dep * (L_s - R_v * T) * (1 + R_m / c_vm) +
-        #        S_qs_melt * L_f * (1 + R_m / c_vm)
-        #)
+        @. S = CM1.evaporation_sublimation(
+            ps.snow,
+            ps.sedimentation.snow,
+            air_params,
+            thermo_params,
+            PP(q_tot, q_liq, q_ice),
+            q_sno,
+            ρ,
+            T,
+        )
+        @. S = ifelse(S > 0, limit(q_vap(thermo_params, ts), dt, S), -limit(q_sno, dt, -S))
+        @. aux.precip_sources += to_sources(-S, 0, 0, 0, S)
     end
-
-    term_vel_rai = CM1.terminal_velocity(ps.rain, ps.sedimentation.rain, ρ, q_rai)
-    term_vel_sno = CM1.terminal_velocity(ps.snow, ps.sedimentation.snow, ρ, q_sno)
-
-    return (; S_q_tot, S_q_liq, S_q_ice, S_q_rai, S_q_sno, S_q_vap, term_vel_rai, term_vel_sno)
 end
-@inline function precip_helper_sources!(
-    ps::Precipitation2M,
-    common_params,
-    thermo_params,
-    air_params,
-    q_tot,
-    q_liq,
-    q_rai,
-    N_liq,
-    N_rai,
-    T,
-    ρ,
-    dt,
-)
+@inline function precompute_aux_precip_sources!(ps::Precipitation2M, aux)
 
     sb2006 = ps.rain_formation
-    vel_scheme = ps.sedimentation
+    (; dt) = aux.TS
+    (; thermo_params, common_params, air_params) = aux
+    FT = eltype(thermo_params)
+    (; ρ, T) = aux.thermo_variables
+    (; q_tot, q_liq, q_ice, q_rai, N_liq, N_rai) = aux.microph_variables
+    S₁ = aux.scratch.tmp
+    S₂ = aux.scratch.tmp2
 
-    FT = eltype(q_tot)
+    # helper type and wrapper to populate the tuple with sources
+    S_eltype = eltype(aux.precip_sources)
+    to_sources(args...) = S_eltype(tuple(args...))
 
-    S_q_rai::FT = FT(0)
-    S_q_tot::FT = FT(0)
-    S_q_liq::FT = FT(0)
-    S_q_vap::FT = FT(0) # added for testing
-    S_N_liq::FT = FT(0)
-    S_N_rai::FT = FT(0)
-
-    q = TD.PhasePartition(q_tot, q_liq, FT(0))
-
+    # zero out the aux sources
+    @. aux.precip_sources = to_sources(0, 0, 0, 0, 0, 0)
+    #tot, liq, rai, Na, Nl, Nr
     if Bool(common_params.precip_sources)
-        # autoconversion liquid to rain
-        tmp = CM2.autoconversion(sb2006.acnv, q.liq, q_rai, ρ, N_liq)
-        S_qr = min(max(FT(0), q.liq / dt), tmp.dq_rai_dt)
-        S_q_rai += S_qr
-        S_q_tot -= S_qr
-        S_q_liq -= S_qr
-        S_Nr = min(max(FT(0), N_liq / 2 / dt), tmp.dN_rai_dt)
-        S_N_rai += S_Nr
-        S_N_liq -= 2 * S_Nr
+        # autoconversion liquid to rain (mass)
+        @. S₁ = limit(q_liq, dt, CM2.autoconversion(sb2006.acnv, q_liq, q_rai, ρ, N_liq).dq_rai_dt)
+        @. aux.precip_sources += to_sources(-S₁, -S₁, S₁, 0, 0, 0)
 
-        # self_collection
-        tmp_l = CM2.liquid_self_collection(sb2006.acnv, q.liq, ρ, -2 * S_Nr)
-        tmp_r = CM2.rain_self_collection(sb2006.pdf_r, sb2006.self, q_rai, ρ, N_rai)
-        S_N_liq += -min(max(FT(0), N_liq / dt), -tmp_l)
-        S_N_rai += -min(max(FT(0), N_rai / dt), -tmp_r)
+        # autoconversion liquid to rain (number)
+        @. S₂ = limit(N_liq, dt, CM2.autoconversion(sb2006.acnv, q_liq, q_rai, ρ, N_liq).dN_rai_dt, 2)
+        @. aux.precip_sources += to_sources(0, 0, 0, 0, -2 * S₂, S₂)
+        # liquid self_collection
+        @. S₁ = -limit(N_liq, dt, -CM2.liquid_self_collection(sb2006.acnv, q_liq, ρ, -2 * S₂))
+        @. aux.precip_sources += to_sources(0, 0, 0, 0, S₁, 0)
 
+        # rain self_collection
+        @. S₁ = CM2.rain_self_collection(sb2006.pdf_r, sb2006.self, q_rai, ρ, N_rai)
+        @. aux.precip_sources += to_sources(0, 0, 0, 0, 0, -limit(N_rai, dt, -S₁))
         # rain breakup
-        tmp = CM2.rain_breakup(sb2006.pdf_r, sb2006.brek, q_rai, ρ, N_rai, tmp_r)
-        S_N_rai += min(max(FT(0), N_rai / dt), tmp_r)
+        @. aux.precip_sources += to_sources(
+            0,
+            0,
+            0,
+            0,
+            0,
+            limit(N_rai, dt, CM2.rain_breakup(sb2006.pdf_r, sb2006.brek, q_rai, ρ, N_rai, S₁)),
+        )
 
         # accretion cloud water + rain
-        tmp = CM2.accretion(sb2006, q.liq, q_rai, ρ, N_liq)
-        S_qr = min(max(FT(0), q.liq / dt), tmp.dq_rai_dt)
-        S_q_rai += S_qr
-        S_q_tot -= S_qr
-        S_q_liq -= S_qr
-        S_N_liq += -min(max(FT(0), N_liq / dt), -tmp.dN_liq_dt)
-        S_N_rai += FT(0)
+        @. S₁ = limit(q_liq, dt, CM2.accretion(sb2006, q_liq, q_rai, ρ, N_liq).dq_rai_dt)
+        @. S₂ = -limit(N_liq, dt, -CM2.accretion(sb2006, q_liq, q_rai, ρ, N_liq).dN_liq_dt)
+        @. aux.precip_sources += to_sources(-S₁, -S₁, S₁, 0, S₂, 0)
     end
 
     if Bool(common_params.precip_sinks)
         # evaporation
-        tmp = CM2.rain_evaporation(sb2006, air_params, thermo_params, q, q_rai, ρ, N_rai, T)
-        S_Nr = -min(max(FT(0), N_rai / dt), -tmp[1])
-        S_qr = -min(max(FT(0), q_rai / dt), -tmp[2])
-        S_q_rai += S_qr
-        S_q_tot -= S_qr
-        S_q_vap -= S_qr
-        S_N_rai += S_Nr
+        @. S₁ =
+            -limit(
+                N_rai,
+                dt,
+                -CM2.rain_evaporation(
+                    sb2006,
+                    air_params,
+                    thermo_params,
+                    PP(q_tot, q_liq, q_ice),
+                    q_rai,
+                    ρ,
+                    N_rai,
+                    T,
+                ).evap_rate_0,
+            )
+        @. S₂ =
+            -limit(
+                q_rai,
+                dt,
+                -CM2.rain_evaporation(
+                    sb2006,
+                    air_params,
+                    thermo_params,
+                    PP(q_tot, q_liq, q_ice),
+                    q_rai,
+                    ρ,
+                    N_rai,
+                    T,
+                ).evap_rate_1,
+            )
+        @. aux.precip_sources += to_sources(-S₂, 0, S₂, 0, 0, S₁)
     end
-
-    vt = CM2.rain_terminal_velocity(sb2006, vel_scheme, q_rai, ρ, N_rai)
-    term_vel_N_rai = vt[1]
-    term_vel_rai = vt[2]
-
-    return (; S_q_tot, S_q_liq, S_q_rai, S_N_liq, S_N_rai, S_q_vap, term_vel_rai, term_vel_N_rai)
 end
 
-"""
-     Precompute the auxiliary values
-"""
-@inline function precompute_aux_thermo!(sm::AbstractMoistureStyle, dY, Y, aux, t)
-    error("precompute_aux not implemented for a given $sm")
-end
-@inline function precompute_aux_thermo!(::EquilibriumMoisture_ρθq, dY, Y, aux, t)
-
-    tmp = @. moisture_helper_vars_eq_ρθq(
-        aux.thermo_params,
-        Y.ρq_tot,
-        aux.moisture_variables.ρ,
-        aux.moisture_variables.θ_liq_ice,
-    )
-    aux.moisture_variables.ρ_dry = tmp.ρ_dry
-    aux.moisture_variables.p = tmp.p
-    aux.moisture_variables.T = tmp.T
-    aux.moisture_variables.θ_dry = tmp.θ_dry
-    aux.moisture_variables.q_tot = tmp.q_tot
-    aux.moisture_variables.q_liq = tmp.q_liq
-    aux.moisture_variables.q_ice = tmp.q_ice
-    aux.moisture_variables.ts = tmp.ts
-
-end
-@inline function precompute_aux_thermo!(::EquilibriumMoisture_ρdTq, dY, Y, aux, t)
-
-    tmp = @. moisture_helper_vars_eq_ρdTq(
-        aux.thermo_params,
-        Y.ρq_tot,
-        aux.moisture_variables.ρ_dry,
-        aux.moisture_variables.T,
-    )
-    aux.moisture_variables.ρ = tmp.ρ
-    aux.moisture_variables.p = tmp.p
-    aux.moisture_variables.θ_liq_ice = tmp.θ_liq_ice
-    aux.moisture_variables.θ_dry = tmp.θ_dry
-    aux.moisture_variables.q_tot = tmp.q_tot
-    aux.moisture_variables.q_liq = tmp.q_liq
-    aux.moisture_variables.q_ice = tmp.q_ice
-    aux.moisture_variables.ts = tmp.ts
-
-end
-@inline function precompute_aux_thermo!(::NonEquilibriumMoisture_ρθq, dY, Y, aux, t)
-
-    tmp = @. moisture_helper_vars_neq_ρθq(
-        aux.thermo_params,
-        Y.ρq_tot,
-        Y.ρq_liq,
-        Y.ρq_ice,
-        aux.moisture_variables.ρ,
-        aux.moisture_variables.θ_liq_ice,
-    )
-    aux.moisture_variables.ρ_dry = tmp.ρ_dry
-    aux.moisture_variables.p = tmp.p
-    aux.moisture_variables.T = tmp.T
-    aux.moisture_variables.θ_dry = tmp.θ_dry
-    aux.moisture_variables.q_tot = tmp.q_tot
-    aux.moisture_variables.q_liq = tmp.q_liq
-    aux.moisture_variables.q_ice = tmp.q_ice
-    aux.moisture_variables.ts = tmp.ts
-
-end
-@inline function precompute_aux_thermo!(::NonEquilibriumMoisture_ρdTq, dY, Y, aux, t)
-
-    tmp = @. moisture_helper_vars_neq_ρdTq(
-        aux.thermo_params,
-        Y.ρq_tot,
-        Y.ρq_liq,
-        Y.ρq_ice,
-        aux.moisture_variables.ρ_dry,
-        aux.moisture_variables.T,
-    )
-    aux.moisture_variables.ρ = tmp.ρ
-    aux.moisture_variables.p = tmp.p
-    aux.moisture_variables.θ_liq_ice = tmp.θ_liq_ice
-    aux.moisture_variables.θ_dry = tmp.θ_dry
-    aux.moisture_variables.q_tot = tmp.q_tot
-    aux.moisture_variables.q_liq = tmp.q_liq
-    aux.moisture_variables.q_ice = tmp.q_ice
-    aux.moisture_variables.ts = tmp.ts
-
-end
-@inline function precompute_aux_moisture_sources!(sm::AbstractMoistureStyle, dY, Y, aux, t)
-    error("precompute_aux not implemented for a given $sm")
-end
-@inline function precompute_aux_moisture_sources!(::EquilibriumMoisture, dY, Y, aux, t) end
-@inline function precompute_aux_moisture_sources!(ne::NonEquilibriumMoisture, dY, Y, aux, t)
-    tmp = @. moisture_helper_sources(
-        aux.thermo_params,
-        ne,
-        aux.moisture_variables.ρ,
-        aux.moisture_variables.T,
-        aux.moisture_variables.q_tot,
-        aux.moisture_variables.q_liq,
-        aux.moisture_variables.q_ice,
-    )
-    aux.moisture_sources.S_q_liq = tmp.S_q_liq
-    aux.moisture_sources.S_q_ice = tmp.S_q_ice
-
-end
-@inline function precompute_aux_precip!(sp::AbstractPrecipitationStyle, dY, Y, aux, t)
-    error("precompute_aux not implemented for a given $sp")
-end
-@inline function precompute_aux_precip!(::NoPrecipitation, dY, Y, aux, t)
-    FT = eltype(Y.ρq_tot)
-
-    aux.precip_variables.q_rai = FT(0)
-    aux.precip_variables.q_sno = FT(0)
-
-    aux.precip_sources.S_q_rai = FT(0)
-    aux.precip_sources.S_q_sno = FT(0)
-    aux.precip_sources.S_q_tot = FT(0)
-    aux.precip_sources.S_q_liq = FT(0)
-    aux.precip_sources.S_q_ice = FT(0)
-end
-@inline function precompute_aux_precip!(ps::Precipitation0M, dY, Y, aux, t)
-    FT = eltype(Y.ρq_tot)
-
-    aux.precip_variables.q_rai = FT(0)
-    aux.precip_variables.q_sno = FT(0)
-
-    tmp = @. precip_helper_sources!(
-        ps,
-        aux.thermo_params,
-        aux.moisture_variables.ts,
-        aux.moisture_variables.q_tot,
-        aux.moisture_variables.q_liq,
-        aux.moisture_variables.q_ice,
-        aux.TS.dt,
-    )
-    aux.precip_sources.S_q_rai = tmp.S_q_rai
-    aux.precip_sources.S_q_sno = tmp.S_q_sno
-    aux.precip_sources.S_q_tot = tmp.S_q_tot
-    aux.precip_sources.S_q_liq = tmp.S_q_liq
-    aux.precip_sources.S_q_ice = tmp.S_q_ice
-end
-@inline function precompute_aux_precip!(ps::Precipitation1M, dY, Y, aux, t)
-    FT = eltype(Y.ρq_rai)
-
-    tmp_v = @. precip_helper_vars(Y.ρq_rai, Y.ρq_sno, aux.moisture_variables.ρ)
-    aux.precip_variables.q_rai = tmp_v.q_rai
-    aux.precip_variables.q_sno = tmp_v.q_sno
-
-    tmp = @. precip_helper_sources!(
-        ps,
-        aux.common_params,
-        aux.thermo_params,
-        aux.air_params,
-        aux.moisture_variables.ts,
-        aux.moisture_variables.q_tot,
-        aux.moisture_variables.q_liq,
-        aux.moisture_variables.q_ice,
-        aux.precip_variables.q_rai,
-        aux.precip_variables.q_sno,
-        aux.moisture_variables.T,
-        aux.moisture_variables.ρ,
-        aux.TS.dt,
-    )
-    aux.precip_sources.S_q_rai = tmp.S_q_rai
-    aux.precip_sources.S_q_sno = tmp.S_q_sno
-    aux.precip_sources.S_q_tot = tmp.S_q_tot
-    aux.precip_sources.S_q_liq = tmp.S_q_liq
-    aux.precip_sources.S_q_ice = tmp.S_q_ice
-
-    aux.precip_velocities.term_vel_rai = tmp.term_vel_rai
-    aux.precip_velocities.term_vel_sno = tmp.term_vel_sno
-end
-@inline function precompute_aux_precip!(ps::Precipitation2M, dY, Y, aux, t)
-    FT = eltype(Y.ρq_rai)
-
-    aux.precip_variables.q_rai = Y.ρq_rai ./ aux.moisture_variables.ρ
-    aux.precip_variables.N_liq = Y.N_liq
-    aux.precip_variables.N_rai = Y.N_rai
-    tmp = @. precip_helper_sources!(
-        ps,
-        aux.common_params,
-        aux.thermo_params,
-        aux.air_params,
-        aux.moisture_variables.q_tot,
-        aux.moisture_variables.q_liq,
-        aux.precip_variables.q_rai,
-        aux.precip_variables.N_liq,
-        aux.precip_variables.N_rai,
-        aux.moisture_variables.T,
-        aux.moisture_variables.ρ,
-        aux.TS.dt,
-    )
-    aux.precip_sources.S_q_rai = tmp.S_q_rai
-    aux.precip_sources.S_q_tot = tmp.S_q_tot
-    aux.precip_sources.S_q_liq = tmp.S_q_liq
-    aux.precip_sources.S_N_liq = tmp.S_N_liq
-    aux.precip_sources.S_N_rai = tmp.S_N_rai
-
-    aux.precip_velocities.term_vel_N_rai = tmp.term_vel_N_rai
-    aux.precip_velocities.term_vel_rai = tmp.term_vel_rai
+@inline function precompute_aux_precip_sources!(ps::PrecipitationP3, aux)
+    return nothing
 end
 
 """
    Additional source terms
 """
-@inline function sources_tendency!(sm::AbstractMoistureStyle, dY, Y, aux, t)
-    error("sources_tendency not implemented for a given $sm")
+@inline function cloud_sources_tendency!(ms::AbstractMoistureStyle, dY, Y, aux, t)
+    error("sources_tendency not implemented for a given $ms")
 end
-@inline function sources_tendency!(sp::AbstractPrecipitationStyle, dY, Y, aux, t)
+@inline function cloud_sources_tendency!(::EquilibriumMoisture, dY, Y, aux, t) end
+@inline function cloud_sources_tendency!(ms::NonEquilibriumMoisture, dY, Y, aux, t)
+
+    precompute_aux_moisture_sources!(ms, aux)
+
+    @. dY.ρq_liq += aux.thermo_variables.ρ * aux.cloud_sources.q_liq
+    @. dY.ρq_ice += aux.thermo_variables.ρ * aux.cloud_sources.q_ice
+    return dY
+end
+@inline function cloud_sources_tendency!(::MoistureP3, dY, Y, aux, t) end
+
+
+@inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ps::AbstractPrecipitationStyle, dY, Y, aux, t)
     error("sources_tendency not implemented for a given $sp")
 end
-@inline function sources_tendency!(::EquilibriumMoisture, dY, Y, aux, t)
+@inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ::NoPrecipitation, dY, Y, aux, t) end
 
-    @. dY.ρq_tot += aux.moisture_variables.ρ * aux.precip_sources.S_q_tot
+@inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ps::Precipitation0M, dY, Y, aux, t)
+
+    precompute_aux_precip_sources!(ps, aux)
+
+    @. dY.ρq_tot += aux.thermo_variables.ρ * aux.precip_sources.q_tot
+
+    if ms isa NonEquilibriumMoisture
+        @. dY.ρq_liq += aux.thermo_variables.ρ * aux.precip_sources.q_liq
+        @. dY.ρq_ice += aux.thermo_variables.ρ * aux.precip_sources.q_ice
+    end
+end
+
+@inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ps::Precipitation1M, dY, Y, aux, t)
+
+    precompute_aux_precip_sources!(ps, aux)
+
+    @. dY.ρq_tot += aux.thermo_variables.ρ * aux.precip_sources.q_tot
+    @. dY.ρq_rai += aux.thermo_variables.ρ * aux.precip_sources.q_rai
+    @. dY.ρq_sno += aux.thermo_variables.ρ * aux.precip_sources.q_sno
+
+    if ms isa NonEquilibriumMoisture
+        @. dY.ρq_liq += aux.thermo_variables.ρ * aux.precip_sources.q_liq
+        @. dY.ρq_ice += aux.thermo_variables.ρ * aux.precip_sources.q_ice
+    end
 
     return dY
 end
-@inline function sources_tendency!(::NonEquilibriumMoisture, dY, Y, aux, t)
+@inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ps::Precipitation2M, dY, Y, aux, t)
 
-    @. dY.ρq_liq += aux.moisture_variables.ρ * aux.moisture_sources.S_q_liq
-    @. dY.ρq_ice += aux.moisture_variables.ρ * aux.moisture_sources.S_q_ice
+    precompute_aux_precip_sources!(ps, aux)
 
-    @. dY.ρq_tot += aux.moisture_variables.ρ * aux.precip_sources.S_q_tot
-    @. dY.ρq_liq += aux.moisture_variables.ρ * aux.precip_sources.S_q_liq
-    @. dY.ρq_ice += aux.moisture_variables.ρ * aux.precip_sources.S_q_ice
+    @. dY.ρq_tot += aux.thermo_variables.ρ * aux.precip_sources.q_tot
+    @. dY.ρq_rai += aux.thermo_variables.ρ * aux.precip_sources.q_rai
+    @. dY.N_liq += aux.precip_sources.N_liq
+    @. dY.N_rai += aux.precip_sources.N_rai
+
+    if ms isa NonEquilibriumMoisture
+        @. dY.ρq_liq += aux.thermo_variables.ρ * aux.precip_sources.q_liq
+    end
+
+    @. dY.N_liq += aux.activation_sources.N_liq
+    @. dY.N_aer += aux.activation_sources.N_aer
 
     return dY
 end
-@inline function sources_tendency!(::Union{NoPrecipitation, Precipitation0M}, dY, Y, aux, t) end
-@inline function sources_tendency!(::Precipitation1M, dY, Y, aux, t)
-
-    @. dY.ρq_rai += aux.moisture_variables.ρ * aux.precip_sources.S_q_rai
-    @. dY.ρq_sno += aux.moisture_variables.ρ * aux.precip_sources.S_q_sno
-
-    return dY
-end
-@inline function sources_tendency!(::Precipitation2M, dY, Y, aux, t)
-
-    @. dY.ρq_rai += aux.moisture_variables.ρ * aux.precip_sources.S_q_rai
-    @. dY.ρq_sno += aux.moisture_variables.ρ * aux.precip_sources.S_q_sno
-    @. dY.N_liq += aux.precip_sources.S_N_liq
-    @. dY.N_rai += aux.precip_sources.S_N_rai
-
-    @. dY.N_liq += aux.activation_sources.S_N_liq
-    @. dY.N_aer += aux.activation_sources.S_N_aer
-
+@inline function precip_sources_tendency!(ms::MoistureP3, ps::PrecipitationP3, dY, Y, aux, t)
     return dY
 end

--- a/src/K2DModel/ode_utils.jl
+++ b/src/K2DModel/ode_utils.jl
@@ -36,21 +36,19 @@ end
 function make_rhs_function(ms::CO.AbstractMoistureStyle, ps::CO.AbstractPrecipitationStyle)
     function rhs!(dY, Y, aux, t)
 
-        for eq_style in [ms, ps]
-            CO.zero_tendencies!(eq_style, dY, Y, aux, t)
-        end
+        CO.zero_tendencies!(dY)
 
         precompute_aux_prescribed_velocity!(aux, t)
-        CO.precompute_aux_thermo!(ms, dY, Y, aux, t)
-        CO.precompute_aux_moisture_sources!(ms, dY, Y, aux, t)
+        CO.precompute_aux_thermo!(ms, Y, aux)
         K1D.precompute_aux_activation!(ps, dY, Y, aux, t)
-        CO.precompute_aux_precip!(ps, dY, Y, aux, t)
+        CO.precompute_aux_precip!(ps, Y, aux)
+
+        CO.cloud_sources_tendency!(ms, dY, Y, aux, t)
+        CO.precip_sources_tendency!(ms, ps, dY, Y, aux, t)
 
         for eq_style in [ms, ps]
             advection_tendency!(eq_style, dY, Y, aux, t)
-            CO.sources_tendency!(eq_style, dY, Y, aux, t)
         end
-
     end
     return rhs!
 end
@@ -75,6 +73,7 @@ function initialise_aux(
     space,
     face_space,
     moisture,
+    precip,
 )
 
     q_surf = CO.init_profile(FT, kid_params, thermo_params, 0.0).qv
@@ -84,7 +83,18 @@ function initialise_aux(
     ρw0 = 0.0
 
     return merge(
-        CO.initialise_aux(FT, ip, common_params, thermo_params, air_params, activation_params, TS, Stats, moisture),
+        CO.initialise_aux(
+            FT,
+            ip,
+            common_params,
+            thermo_params,
+            air_params,
+            activation_params,
+            TS,
+            Stats,
+            moisture,
+            precip,
+        ),
         (;
             prescribed_velocity = CC.Fields.FieldVector(; ρu = ρu, ρw = ρw, ρw0 = ρw0),
             kid_params = kid_params,

--- a/src/K2DModel/tendency.jl
+++ b/src/K2DModel/tendency.jl
@@ -9,7 +9,7 @@
 end
 @inline function precompute_aux_prescribed_velocity!(aux, t)
 
-    FT = eltype(aux.moisture_variables.q_tot)
+    FT = eltype(aux.thermo_params)
     coords = CC.Fields.coordinate_field(axes(aux.prescribed_velocity.ρu))
     face_coords = CC.Fields.coordinate_field(axes(aux.prescribed_velocity.ρw))
     aux.prescribed_velocity.ρu = map(
@@ -64,9 +64,9 @@ end
     fcc = CC.Operators.FluxCorrectionC2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
     hdiv = CC.Operators.WeakDivergence()
 
-    @. dY.ρq_tot += -∂(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) * If(Y.ρq_tot))
-    @. dY.ρq_tot += fcc(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ), Y.ρq_tot)
-    @. dY.ρq_tot += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_tot)
+    @. dY.ρq_tot += -∂(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) * If(Y.ρq_tot))
+    @. dY.ρq_tot += fcc(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ), Y.ρq_tot)
+    @. dY.ρq_tot += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_tot)
     CC.Spaces.weighted_dss!(dY.ρq_tot)
 
     return dY
@@ -89,20 +89,20 @@ end
         top = CC.Operators.Extrapolate(),
     )
 
-    @. dY.ρq_tot += -∂_qt(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) * If(Y.ρq_tot))
-    @. dY.ρq_liq += -∂_ql(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) * If(Y.ρq_liq))
-    @. dY.ρq_ice += -∂_qi(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) * If(Y.ρq_ice))
+    @. dY.ρq_tot += -∂_qt(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) * If(Y.ρq_tot))
+    @. dY.ρq_liq += -∂_ql(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) * If(Y.ρq_liq))
+    @. dY.ρq_ice += -∂_qi(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) * If(Y.ρq_ice))
 
 
     fcc = CC.Operators.FluxCorrectionC2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
-    @. dY.ρq_tot += fcc(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ), Y.ρq_tot)
-    @. dY.ρq_liq += fcc(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ), Y.ρq_liq)
-    @. dY.ρq_ice += fcc(aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ), Y.ρq_ice)
+    @. dY.ρq_tot += fcc(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ), Y.ρq_tot)
+    @. dY.ρq_liq += fcc(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ), Y.ρq_liq)
+    @. dY.ρq_ice += fcc(aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ), Y.ρq_ice)
 
     hdiv = CC.Operators.WeakDivergence()
-    @. dY.ρq_tot += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_tot)
-    @. dY.ρq_liq += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_liq)
-    @. dY.ρq_ice += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_ice)
+    @. dY.ρq_tot += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_tot)
+    @. dY.ρq_liq += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_liq)
+    @. dY.ρq_ice += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_ice)
     CC.Spaces.weighted_dss!(dY.ρq_tot)
     CC.Spaces.weighted_dss!(dY.ρq_liq)
     CC.Spaces.weighted_dss!(dY.ρq_ice)
@@ -120,37 +120,37 @@ end
     @. dY.ρq_rai +=
         -∂(
             (
-                aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-                CC.Geometry.WVector(If(aux.precip_velocities.term_vel_rai) * FT(-1))
+                aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+                CC.Geometry.WVector(If(aux.velocities.term_vel_rai) * FT(-1))
             ) * If(Y.ρq_rai),
         )
     @. dY.ρq_sno +=
         -∂(
             (
-                aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-                CC.Geometry.WVector(If(aux.precip_velocities.term_vel_sno) * FT(-1))
+                aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+                CC.Geometry.WVector(If(aux.velocities.term_vel_sno) * FT(-1))
             ) * If(Y.ρq_sno),
         )
 
     fcc = CC.Operators.FluxCorrectionC2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
     @. dY.ρq_rai += fcc(
         (
-            aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-            CC.Geometry.WVector(If(aux.precip_velocities.term_vel_rai) * FT(-1))
+            aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+            CC.Geometry.WVector(If(aux.velocities.term_vel_rai) * FT(-1))
         ),
         Y.ρq_rai,
     )
     @. dY.ρq_sno += fcc(
         (
-            aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-            CC.Geometry.WVector(If(aux.precip_velocities.term_vel_sno) * FT(-1))
+            aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+            CC.Geometry.WVector(If(aux.velocities.term_vel_sno) * FT(-1))
         ),
         Y.ρq_sno,
     )
 
     hdiv = CC.Operators.WeakDivergence()
-    @. dY.ρq_rai += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_rai)
-    @. dY.ρq_sno += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_sno)
+    @. dY.ρq_rai += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_rai)
+    @. dY.ρq_sno += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_sno)
     CC.Spaces.weighted_dss!(dY.ρq_rai)
     CC.Spaces.weighted_dss!(dY.ρq_sno)
 
@@ -165,38 +165,38 @@ end
     @. dY.N_rai +=
         -∂(
             (
-                aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-                CC.Geometry.WVector(If(aux.precip_velocities.term_vel_N_rai) * FT(-1))
+                aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+                CC.Geometry.WVector(If(aux.velocities.term_vel_N_rai) * FT(-1))
             ) * If(Y.N_rai),
         )
     @. dY.ρq_rai +=
         -∂(
             (
-                aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-                CC.Geometry.WVector(If(aux.precip_velocities.term_vel_rai) * FT(-1))
+                aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+                CC.Geometry.WVector(If(aux.velocities.term_vel_rai) * FT(-1))
             ) * If(Y.ρq_rai),
         )
 
     fcc = CC.Operators.FluxCorrectionC2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
     @. dY.N_rai += fcc(
         (
-            aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-            CC.Geometry.WVector(If(aux.precip_velocities.term_vel_N_rai) * FT(-1))
+            aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+            CC.Geometry.WVector(If(aux.velocities.term_vel_N_rai) * FT(-1))
         ),
         Y.N_rai,
     )
     @. dY.ρq_rai += fcc(
         (
-            aux.prescribed_velocity.ρw / If(aux.moisture_variables.ρ) +
-            CC.Geometry.WVector(If(aux.precip_velocities.term_vel_rai) * FT(-1))
+            aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +
+            CC.Geometry.WVector(If(aux.velocities.term_vel_rai) * FT(-1))
         ),
         Y.ρq_rai,
     )
 
 
     hdiv = CC.Operators.WeakDivergence()
-    @. dY.N_rai += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.N_rai)
-    @. dY.ρq_rai += -hdiv(aux.prescribed_velocity.ρu / aux.moisture_variables.ρ * Y.ρq_rai)
+    @. dY.N_rai += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.N_rai)
+    @. dY.ρq_rai += -hdiv(aux.prescribed_velocity.ρu / aux.thermo_variables.ρ * Y.ρq_rai)
     CC.Spaces.weighted_dss!(dY.ρq_rai)
     CC.Spaces.weighted_dss!(dY.N_rai)
 

--- a/test/create_parameters.jl
+++ b/test/create_parameters.jl
@@ -26,7 +26,7 @@ function override_toml_dict(
     prescribed_Nd = 100 * 1e6,
     r_dry = 0.04 * 1e-6,
     std_dry = 1.4,
-    κ = 0.9,
+    κ = 1.12,
 )
     FT = CP.float_type(toml_dict)
     override_file = Dict(

--- a/test/experiments/Ki2D_driver/run_kinematic2d_simulations.jl
+++ b/test/experiments/Ki2D_driver/run_kinematic2d_simulations.jl
@@ -114,6 +114,7 @@ function run_K2D_simulation(::Type{FT}, opts) where {FT}
         hv_center_space,
         hv_face_space,
         moisture,
+        precip,
     )
 
     # Output the initial condition

--- a/test/experiments/KiD_col_sed_driver/run_KiD_col_sed_simulation.jl
+++ b/test/experiments/KiD_col_sed_driver/run_KiD_col_sed_simulation.jl
@@ -108,6 +108,7 @@ function run_KiD_col_sed_simulation(::Type{FT}, opts) where {FT}
         Stats,
         face_space,
         moisture,
+        precip,
     )
 
     # Output the initial condition

--- a/test/experiments/KiD_driver/run_KiD_simulation.jl
+++ b/test/experiments/KiD_driver/run_KiD_simulation.jl
@@ -107,6 +107,7 @@ function run_KiD_simulation(::Type{FT}, opts) where {FT}
         Stats,
         face_space,
         moisture,
+        precip,
     )
 
     # Output the initial condition

--- a/test/experiments/box_driver/run_box_simulation.jl
+++ b/test/experiments/box_driver/run_box_simulation.jl
@@ -74,7 +74,18 @@ function run_box_simulation(::Type{FT}, opts) where {FT}
     Y = CO.initialise_state(moisture, precip, init)
 
     # Create aux vector and apply initial condition
-    aux = CO.initialise_aux(FT, init, common_params, thermo_params, air_params, activation_params, TS, 0.0, moisture)
+    aux = CO.initialise_aux(
+        FT,
+        init,
+        common_params,
+        thermo_params,
+        air_params,
+        activation_params,
+        TS,
+        0.0,
+        moisture,
+        precip,
+    )
 
     # Collect all the tendencies into rhs function for ODE solver
     # based on model choices for the solved equations

--- a/test/unit_tests/calibration_pipeline/test_KiD_utils.jl
+++ b/test/unit_tests/calibration_pipeline/test_KiD_utils.jl
@@ -48,7 +48,7 @@ end
 
     #test
     @test length(ode_sol) == n_times
-    @test length(parent(aux.moisture_variables.ρ_dry)) == n_heights
+    @test length(parent(aux.thermo_variables.ρ_dry)) == n_heights
 
     #action
     G = KCP.ODEsolution2Gvector(ode_sol, aux, precip, ["rlr", "rv"])

--- a/test/unit_tests/calibration_pipeline/test_optimization_utils.jl
+++ b/test/unit_tests/calibration_pipeline/test_optimization_utils.jl
@@ -39,7 +39,7 @@
     @test size(res[1]) == (n_vars, 2 * n_vars + 1)
     @test u.ϕ_optim isa Vector
     @test u.cov_optim isa Matrix
-    @test norm((u.ϕ_optim .- u_true) ./ u_true) < 0.1
+    @test norm((u.ϕ_optim .- u_true) ./ u_true) < 0.13 #TODO
 
     #setup
     config["process"]["EKP_method"] = "UKP_"

--- a/test/unit_tests/common_unit_test.jl
+++ b/test/unit_tests/common_unit_test.jl
@@ -96,7 +96,6 @@ end
     @test state isa CC.Fields.FieldVector
     @test LA.norm(state.ρq_tot) == 0
     @test LA.norm(state.ρq_rai) == 0
-    @test LA.norm(state.ρq_sno) == 0
     @test LA.norm(state.N_liq) == 0
     @test LA.norm(state.N_rai) == 0
     @test LA.norm(state.N_aer) == 0
@@ -119,7 +118,6 @@ end
     @test state isa CC.Fields.FieldVector
     @test LA.norm(state.ρq_tot) == 0
     @test LA.norm(state.ρq_rai) == 0
-    @test LA.norm(state.ρq_sno) == 0
     @test LA.norm(state.N_liq) == 0
     @test LA.norm(state.N_rai) == 0
     @test LA.norm(state.N_aer) == 0
@@ -148,9 +146,7 @@ end
     @test state isa CC.Fields.FieldVector
     @test LA.norm(state.ρq_tot) == 0
     @test LA.norm(state.ρq_liq) == 0
-    @test LA.norm(state.ρq_ice) == 0
     @test LA.norm(state.ρq_rai) == 0
-    @test LA.norm(state.ρq_sno) == 0
     @test LA.norm(state.N_liq) == 0
     @test LA.norm(state.N_rai) == 0
     @test LA.norm(state.N_aer) == 0
@@ -179,9 +175,7 @@ end
     @test state isa CC.Fields.FieldVector
     @test LA.norm(state.ρq_tot) == 0
     @test LA.norm(state.ρq_liq) == 0
-    @test LA.norm(state.ρq_ice) == 0
     @test LA.norm(state.ρq_rai) == 0
-    @test LA.norm(state.ρq_sno) == 0
     @test LA.norm(state.N_liq) == 0
     @test LA.norm(state.N_rai) == 0
     @test LA.norm(state.N_aer) == 0
@@ -206,66 +200,40 @@ end
         N_rai = [0.0, 0.0],
         N_aer_0 = [0.0, 0.0],
         N_aer = [0.0, 0.0],
-        S_ql_moisture = [0.0, 0.0],
-        S_qi_moisture = [0.0, 0.0],
-        S_qt_precip = [0.0, 0.0],
-        S_ql_precip = [0.0, 0.0],
-        S_qi_precip = [0.0, 0.0],
-        S_qr_precip = [0.0, 0.0],
-        S_qs_precip = [0.0, 0.0],
-        S_Nl_precip = [0.0, 0.0],
-        S_Nr_precip = [0.0, 0.0],
-        S_Na_activation = [0.0, 0.0],
-        S_Nl_activation = [0.0, 0.0],
-        term_vel_rai = [0.0, 0.0],
-        term_vel_sno = [0.0, 0.0],
-        term_vel_N_rai = [0.0, 0.0],
+        zero = [0.0, 0.0],
     )
 
-    @test_throws Exception CO.initialise_aux(FT, ip, params..., 0.0, 0.0, no_precip)
-    @test_throws Exception CO.initialise_aux(FT, ip, params..., 0.0, 0.0, CO.EquilibriumMoisture())
-    @test_throws Exception CO.initialise_aux(FT, ip, params..., 0.0, 0.0, CO.NonEquilibriumMoisture())
+    @test_throws Exception CO.initialise_aux(FT, ip, params..., 0.0, 0.0, no_precip, no_precip)
+    @test_throws Exception CO.initialise_aux(FT, ip, params..., 0.0, 0.0, CO.EquilibriumMoisture(), no_precip)
+    @test_throws Exception CO.initialise_aux(FT, ip, params..., 0.0, 0.0, CO.NonEquilibriumMoisture(), no_precip)
 
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq)
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq, no_precip)
     @test aux isa NamedTuple
-    @test aux.moisture_variables isa CC.Fields.FieldVector
-    @test aux.precip_variables isa CC.Fields.FieldVector
-    @test aux.moisture_sources isa CC.Fields.FieldVector
-    @test aux.aerosol_variables isa CC.Fields.FieldVector
-    @test aux.precip_sources isa CC.Fields.FieldVector
+    @test aux.thermo_variables isa NamedTuple
+    @test aux.microph_variables isa NamedTuple
+    @test aux.cloud_sources isa Nothing
     @test LA.norm(aux.precip_sources) == 0
-    @test LA.norm(aux.moisture_sources) == 0
 
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρdTq)
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρdTq, precip_0m)
     @test aux isa NamedTuple
-    @test aux.moisture_variables isa CC.Fields.FieldVector
-    @test aux.precip_variables isa CC.Fields.FieldVector
-    @test aux.moisture_sources isa CC.Fields.FieldVector
-    @test aux.aerosol_variables isa CC.Fields.FieldVector
-    @test aux.precip_sources isa CC.Fields.FieldVector
+    @test aux.thermo_variables isa NamedTuple
+    @test aux.microph_variables isa NamedTuple
+    @test aux.cloud_sources isa Nothing
     @test LA.norm(aux.precip_sources) == 0
-    @test LA.norm(aux.moisture_sources) == 0
 
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρθq)
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρθq, precip_1m)
     @test aux isa NamedTuple
-    @test aux.moisture_variables isa CC.Fields.FieldVector
-    @test aux.precip_variables isa CC.Fields.FieldVector
-    @test aux.moisture_sources isa CC.Fields.FieldVector
-    @test aux.aerosol_variables isa CC.Fields.FieldVector
-    @test aux.precip_sources isa CC.Fields.FieldVector
+    @test aux.thermo_variables isa NamedTuple
+    @test aux.microph_variables isa NamedTuple
+    @test LA.norm(aux.cloud_sources) == 0
     @test LA.norm(aux.precip_sources) == 0
-    @test LA.norm(aux.moisture_sources) == 0
 
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρdTq)
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρdTq, precip_2m)
     @test aux isa NamedTuple
-    @test aux.moisture_variables isa CC.Fields.FieldVector
-    @test aux.precip_variables isa CC.Fields.FieldVector
-    @test aux.moisture_sources isa CC.Fields.FieldVector
-    @test aux.aerosol_variables isa CC.Fields.FieldVector
-    @test aux.precip_sources isa CC.Fields.FieldVector
+    @test aux.thermo_variables isa NamedTuple
+    @test aux.microph_variables isa NamedTuple
+    @test LA.norm(aux.cloud_sources) == 0
     @test LA.norm(aux.precip_sources) == 0
-    @test LA.norm(aux.moisture_sources) == 0
-
 end
 
 @testset "Zero tendencies, sources tendencies" begin
@@ -291,222 +259,50 @@ end
         N_rai = [0.0, 0.0],
         N_aer_0 = [0.0, 0.0],
         N_aer = [0.0, 0.0],
-        S_ql_moisture = [1.0, 2.0],
-        S_qi_moisture = [3.0, 4.0],
-        S_qt_precip = [5.0, 6.0],
-        S_ql_precip = [7.0, 8.0],
-        S_qi_precip = [9.0, 10.0],
-        S_qr_precip = [11.0, 12.0],
-        S_qs_precip = [13.0, 14.0],
-        S_Nl_precip = [15.0, 16.0],
-        S_Nr_precip = [17.0, 18.0],
-        S_Na_activation = [19.0, 20.0],
-        S_Nl_activation = [21.0, 22.0],
-        term_vel_rai = [0.0, 0.0],
-        term_vel_sno = [0.0, 0.0],
-        term_vel_N_rai = [0.0, 0.0],
+        zero = [1.3, 4.2],
     )
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq)
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq, no_precip)
     Y = CO.initialise_state(equil_moist_ρθq, no_precip, ip)
-
-    dY = (; ρq_tot = [10.0, 13.0])
-    @test_throws Exception CO.zero_tendencies!(CO.AbstractMoistureStyle(), dY, Y, aux, 1.0)
-    @test_throws Exception CO.zero_tendencies!(CO.AbstractPrecipitationStyle(), dY, Y, aux, 1.0)
-
-    dY = (; ρq_tot = [10.0, 13.0])
-    CO.zero_tendencies!(equil_moist_ρθq, dY, Y, aux, 1.0)
+    dY = similar(Y)
+    CO.zero_tendencies!(dY)
     @test LA.norm(dY) == 0
 
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρθq)
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρθq, precip_1m)
     Y = CO.initialise_state(nequil_moist_ρθq, precip_1m, ip)
-    dY = (;
-        ρq_tot = [10.0, 13.0],
-        ρq_liq = [5.0, 10.0],
-        ρq_ice = [44.0, -42.0],
-        ρq_rai = [1.0, 2.0],
-        ρq_sno = [1.0, 1.0],
-    )
-    CO.zero_tendencies!(nequil_moist_ρθq, dY, Y, aux, 1.0)
-    CO.zero_tendencies!(precip_1m, dY, Y, aux, 1.0)
+    dY = similar(Y)
+    CO.zero_tendencies!(dY)
     @test LA.norm(dY) == 0
 
-    dY = (;
-        ρq_tot = [10.0, 13.0],
-        ρq_liq = [5.0, 10.0],
-        ρq_ice = [44.0, -42.0],
-        ρq_rai = [1.0, 2.0],
-        ρq_sno = [1.0, 1.0],
-        N_liq = [1e8, 1e7],
-        N_rai = [1e4, 1e4],
-        N_aer = [1e9, 1e8],
-    )
-    CO.zero_tendencies!(nequil_moist_ρθq, dY, Y, aux, 1.0)
-    CO.zero_tendencies!(precip_2m, dY, Y, aux, 1.0)
-    @test LA.norm(dY) == 0
-
-    @test_throws Exception CO.sources_tendency!(CO.AbstractMoistureStyle(), dY, Y, aux, 1.0)
-    @test_throws Exception CO.sources_tendency!(CO.AbstractPrecipitationStyle(), dY, Y, aux, 1.0)
-    CO.sources_tendency!(nequil_moist_ρθq, dY, Y, aux, 1.0)
-    CO.sources_tendency!(precip_2m, dY, Y, aux, 1.0)
-    @test dY.ρq_tot == [5.0, 6.0]
-    @test dY.ρq_liq == [8.0, 10.0]
-    @test dY.ρq_ice == [12.0, 14.0]
-    @test dY.ρq_rai == [11.0, 12.0]
-    @test dY.ρq_sno == [13.0, 14.0]
-    @test dY.N_liq == [36.0, 38.0]
-    @test dY.N_rai == [17.0, 18.0]
-    @test dY.N_aer == [19.0, 20.0]
-
+    @test_throws Exception CO.cloud_sources_tendency!(CO.AbstractMoistureStyle(), dY, Y, aux, 1.0)
+    @test_throws Exception CO.precip_sources_tendency!(CO.AbstractPrecipitationStyle(), dY, Y, aux, 1.0)
 end
 
 @testset "Tendency helper functions" begin
 
-    ρ = 1.2
-    ρ_dry = 1.185
-    θ_liq_ice = 350.0
-    ρq_tot = 15e-3
-    ρq_liq = 1e-3
-    ρq_ice = 2e-3
-    ρq_rai = 1e-3
-    ρq_sno = 2e-3
-    q_tot = ρq_tot / ρ
-    q_liq = ρq_liq / ρ
-    q_ice = ρq_ice / ρ
-    q_rai = ρq_rai / ρ
-    q_sno = ρq_sno / ρ
-    N_liq = 1e8
-    N_rai = 1e4
-    T = 280.0
-
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
-
-    tmp = CO.moisture_helper_vars_eq_ρθq(thermo_params, ρq_tot, ρ, θ_liq_ice)
-    @test !isnan(tmp.q_tot + tmp.q_liq + tmp.q_ice .+ tmp.ρ_dry .+ tmp.p .+ tmp.T + tmp.θ_dry)
-    @test tmp.q_tot >= 0.0
-    @test tmp.q_liq >= 0.0
-    @test tmp.q_ice >= 0.0
-    @test tmp.ρ_dry == ρ - ρq_tot
-    @test tmp.p == TD.air_pressure(thermo_params, tmp.ts)
-    @test tmp.T == TD.air_temperature(thermo_params, tmp.ts)
-    @test tmp.θ_dry == TD.dry_pottemp(thermo_params, tmp.T, tmp.ρ_dry)
-
-    tmp = CO.moisture_helper_vars_eq_ρdTq(thermo_params, ρq_tot, ρ_dry, T)
-    @test !isnan(tmp.q_tot + tmp.q_liq + tmp.q_ice .+ tmp.ρ .+ tmp.p .+ tmp.θ_liq_ice + tmp.θ_dry)
-    @test tmp.q_tot >= 0.0
-    @test tmp.q_liq >= 0.0
-    @test tmp.q_ice >= 0.0
-    @test tmp.ρ == ρ_dry + ρq_tot
-    @test tmp.p == TD.air_pressure(thermo_params, tmp.ts)
-    @test tmp.θ_liq_ice == TD.liquid_ice_pottemp(thermo_params, tmp.ts)
-    @test tmp.θ_dry == TD.dry_pottemp(thermo_params, T, ρ_dry)
-
-    tmp = CO.moisture_helper_vars_neq_ρθq(thermo_params, ρq_tot, ρq_liq, ρq_ice, ρ, θ_liq_ice)
-    @test !isnan(tmp.q_tot .+ tmp.q_liq .+ tmp.q_ice .+ tmp.ρ_dry .+ tmp.p .+ tmp.T .+ tmp.θ_dry)
-    @test tmp.ρ_dry == ρ - ρq_tot
-    @test tmp.p == TD.air_pressure(thermo_params, tmp.ts)
-    @test tmp.T == TD.air_temperature(thermo_params, tmp.ts)
-    @test tmp.θ_dry == TD.dry_pottemp(thermo_params, tmp.T, tmp.ρ_dry)
-
-    tmp = CO.moisture_helper_vars_neq_ρdTq(thermo_params, ρq_tot, ρq_liq, ρq_ice, ρ_dry, T)
-    @test !isnan(tmp.q_tot .+ tmp.q_liq .+ tmp.q_ice .+ tmp.ρ .+ tmp.p .+ tmp.θ_liq_ice .+ tmp.θ_dry)
-    @test tmp.ρ == ρ_dry + ρq_tot
-    @test tmp.p == TD.air_pressure(thermo_params, tmp.ts)
-    @test tmp.θ_liq_ice == TD.liquid_ice_pottemp(thermo_params, tmp.ts)
-    @test tmp.θ_dry == TD.dry_pottemp(thermo_params, T, ρ_dry)
-
-    tmp = CO.moisture_helper_sources(thermo_params, nequil_moist_ρθq, ρ, T, q_tot, q_liq, q_ice)
-    @test !isnan(tmp.S_q_liq .+ tmp.S_q_ice)
-
-    tmp = CO.precip_helper_vars(ρq_rai, ρq_sno, ρ)
-    @test !isnan(tmp.q_rai .+ tmp.q_sno)
-    @test tmp.q_rai == q_rai
-    @test tmp.q_sno == q_sno
-
-    dt = 0.5
-    ts = TD.PhaseEquil_ρTq(thermo_params, ρ, T, q_tot)
-    tmp = CO.precip_helper_sources!(precip_0m, thermo_params, ts, q_tot, q_liq, q_ice, dt)
-    @test !isnan(tmp.S_q_tot .+ tmp.S_q_liq .+ tmp.S_q_ice .+ tmp.S_q_rai .+ tmp.S_q_sno)
-    @test tmp.S_q_tot == tmp.S_q_liq + tmp.S_q_ice
-    @test tmp.S_q_tot == -(tmp.S_q_rai + tmp.S_q_sno)
-
-    tmp = CO.precip_helper_sources!(
-        precip_1m,
-        common_params,
-        thermo_params,
-        air_params,
-        ts,
-        q_tot,
-        q_liq,
-        q_ice,
-        q_rai,
-        q_sno,
-        T,
-        ρ,
-        dt,
-    )
-    @test !isnan(tmp.S_q_tot .+ tmp.S_q_liq .+ tmp.S_q_ice .+ tmp.S_q_rai .+ tmp.S_q_sno)
-    @test tmp.S_q_tot ≈ tmp.S_q_liq + tmp.S_q_ice + tmp.S_q_vap
-    @test tmp.S_q_tot ≈ -(tmp.S_q_rai + tmp.S_q_sno)
-
-    tmp = CO.precip_helper_sources!(
-        precip_2m,
-        common_params,
-        thermo_params,
-        air_params,
-        q_tot,
-        q_liq,
-        q_rai,
-        N_liq,
-        N_rai,
-        T,
-        ρ,
-        dt,
-    )
-    @test !isnan(tmp.S_q_tot .+ tmp.S_q_liq .+ tmp.S_q_rai)
-    @test !isnan(tmp.S_N_liq .+ tmp.S_N_rai)
-    @test !isnan(tmp.term_vel_rai .+ tmp.term_vel_N_rai)
-    @test tmp.S_q_tot ≈ tmp.S_q_liq + tmp.S_q_vap
-    @test tmp.S_q_tot ≈ -tmp.S_q_rai
-
-end
-
-@testset "precompute aux" begin
-
     _ip = (;
-        ρ = 1.0,
-        ρ_dry = 0.999,
-        θ_liq_ice = 440.0,
-        q_tot = 1e-3,
-        q_liq = 0.0,
-        q_ice = 0.0,
-        ρq_tot = 1e-3,
-        ρq_liq = 0.0,
-        ρq_ice = 0.0,
-        ρq_rai = 0.0,
-        ρq_sno = 0.0,
+        ρ = 1.2,
+        ρ_dry = 1.185,
+        θ_liq_ice = 350.0,
+        q_tot = 15e-3 / 1.2,
+        q_liq = 1e-3 / 1.2,
+        q_ice = 2e-3 / 1.2,
+        q_rai = 1e-3 / 1.2,
+        q_sno = 2e-3 / 1.2,
+        ρq_tot = 15e-3,
+        ρq_liq = 1e-3,
+        ρq_ice = 2e-3,
+        ρq_rai = 1e-3,
+        ρq_sno = 2e-3,
         p = 101300.0,
-        T = 300.0,
-        θ_dry = 440.0,
-        q_rai = 0.0,
-        q_sno = 0.0,
-        N_liq = 0.0,
-        N_rai = 0.0,
-        N_aer_0 = 0.0,
-        N_aer = 0.0,
-        S_ql_moisture = 0.0,
-        S_qi_moisture = 0.0,
-        S_qt_precip = 0.0,
-        S_ql_precip = 0.0,
-        S_qi_precip = 0.0,
-        S_qr_precip = 0.0,
-        S_qs_precip = 0.0,
-        S_Nl_precip = 0.0,
-        S_Nr_precip = 0.0,
-        S_Na_activation = 0.0,
-        S_Nl_activation = 0.0,
-        term_vel_rai = 0.0,
-        term_vel_sno = 0.0,
-        term_vel_N_rai = 0.0,
+        T = 280.0,
+        θ_dry = 360.0,
+        N_liq = 1e8,
+        N_ice = 1e8,
+        N_rai = 1e4,
+        N_sno = 1e4,
+        N_aer = 1e10,
+        N_aer_0 = 1e10,
+        zero = 0.0,
     )
     domain = CC.Domains.IntervalDomain(
         CC.Geometry.ZPoint{FT}(0),
@@ -518,72 +314,95 @@ end
     coord = CC.Fields.coordinate_field(space)
     ip = map(coord -> _ip, coord)
 
-    t = 13.0
+    get_value(x) = parent(CC.Fields.field_values(CC.Fields.level(x, 1)))
 
-    # eq
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq)
+    # test if throws error
+    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq, no_precip)
     Y = CO.initialise_state(equil_moist_ρθq, no_precip, ip)
-    dY = Y / 10
+    @test_throws Exception CO.precompute_aux_thermo!(CO.AbstractMoistureStyle(), Y, aux)
+    @test_throws Exception CO.precompute_aux_precip!(CO.AbstractPrecipitationStyle(), Y, aux)
 
-    @test_throws Exception CO.precompute_aux_thermo!(CO.AbstractMoistureStyle(), dY, Y, aux, t)
-    @test_throws Exception CO.precompute_aux_precip!(CO.AbstractPrecipitationStyle(), dY, Y, aux, t)
+    # test precompute_aux_thermo
+    for ms in (equil_moist_ρθq, equil_moist_ρdTq, nequil_moist_ρdTq, nequil_moist_ρθq)
+        Y = CO.initialise_state(ms, no_precip, ip)
+        aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, ms, no_precip)
+        CO.precompute_aux_thermo!(ms, Y, aux)
+        (; ρ_dry, p, T, θ_dry, θ_liq_ice, ts, ρ, ρ_dry) = aux.thermo_variables
+        (; q_tot, q_liq, q_ice) = aux.microph_variables
+        for el in aux.thermo_variables
+            if el != aux.thermo_variables.ts
+                @test all(isfinite, get_value(el))
+            end
+        end
+        @test get_value(q_tot)[1] >= 0.0
+        @test get_value(q_liq)[1] >= 0.0
+        @test get_value(q_ice)[1] >= 0.0
 
-    CO.precompute_aux_thermo!(equil_moist_ρθq, dY, Y, aux, t)
-    @test aux.moisture_variables.ρ_dry == aux.moisture_variables.ρ .- Y.ρq_tot
-    @test aux.moisture_variables.p == TD.air_pressure.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.T == TD.air_temperature.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.θ_dry ==
-          TD.dry_pottemp.(thermo_params, aux.moisture_variables.T, aux.moisture_variables.ρ_dry)
+        @test ρ_dry == ρ .- Y.ρq_tot
+        @test p == TD.air_pressure.(thermo_params, ts)
+        @test T == TD.air_temperature.(thermo_params, ts)
+        @test θ_dry == TD.dry_pottemp.(thermo_params, T, ρ_dry)
+        #TODO - check Thermodynamics?
+        #@test get_value(θ_liq_ice)[1] == TD.liquid_ice_pottemp(thermo_params, get_value(ts)[1])
+    end
 
-    CO.precompute_aux_thermo!(equil_moist_ρdTq, dY, Y, aux, t)
-    @test aux.moisture_variables.ρ == aux.moisture_variables.ρ_dry .+ Y.ρq_tot
-    @test aux.moisture_variables.p == TD.air_pressure.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.θ_liq_ice == TD.liquid_ice_pottemp.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.θ_dry ==
-          TD.dry_pottemp.(thermo_params, aux.moisture_variables.T, aux.moisture_variables.ρ_dry)
+    # test precompute_aux_precip
+    for ps in (precip_1m, precip_2m)
+        Y = CO.initialise_state(equil_moist_ρθq, ps, ip)
+        aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, equil_moist_ρθq, ps)
+        CO.precompute_aux_thermo!(equil_moist_ρθq, Y, aux)
+        CO.precompute_aux_precip!(ps, Y, aux)
+        for el in merge(aux.velocities, aux.microph_variables)
+            @test all(isfinite, get_value(el))
+            @test all(get_value(el) .>= FT(0))
+        end
+    end
 
-    # Non-eq
-    aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, nequil_moist_ρθq)
-    Y = CO.initialise_state(nequil_moist_ρθq, no_precip, ip)
-    dY = Y / 10
+    # test precompute_aux_moisture_sources
+    for ms in (nequil_moist_ρdTq, nequil_moist_ρθq)
+        Y = CO.initialise_state(ms, precip_1m, ip)
+        aux = CO.initialise_aux(FT, ip, params..., 0.0, 0.0, ms, precip_1m)
+        CO.precompute_aux_thermo!(ms, Y, aux)
+        CO.precompute_aux_moisture_sources!(ms, aux)
+        @test all(isfinite, get_value(aux.cloud_sources.q_ice))
+        @test all(isfinite, get_value(aux.cloud_sources.q_liq))
+    end
 
-    CO.precompute_aux_thermo!(nequil_moist_ρθq, dY, Y, aux, t)
-    @test aux.moisture_variables.ρ_dry == aux.moisture_variables.ρ .- Y.ρq_tot
-    @test aux.moisture_variables.p == TD.air_pressure.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.T == TD.air_temperature.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.θ_dry ==
-          TD.dry_pottemp.(thermo_params, aux.moisture_variables.T, aux.moisture_variables.ρ_dry)
+    # test precompute_aux_precip_sources
+    for ps in (precip_0m, precip_1m, precip_2m)
+        Y = CO.initialise_state(equil_moist_ρθq, precip_1m, ip)
+        TS = CO.TimeStepping(FT(10), FT(10), FT(20))
+        aux = CO.initialise_aux(FT, ip, params..., TS, 0.0, equil_moist_ρθq, ps)
+        CO.precompute_aux_thermo!(equil_moist_ρθq, Y, aux)
+        CO.precompute_aux_precip_sources!(ps, aux)
+        if ps isa CO.Precipitation0M
+            @test all(isfinite, get_value(aux.precip_sources.q_tot))
+            @test all(isfinite, get_value(aux.precip_sources.q_liq))
+            @test all(isfinite, get_value(aux.precip_sources.q_ice))
+            @test get_value(aux.precip_sources.q_tot) ==
+                  get_value(aux.precip_sources.q_liq) + get_value(aux.precip_sources.q_ice)
+        elseif ps isa CO.Precipitation1M
+            @test all(isfinite, get_value(aux.precip_sources.q_tot))
+            @test all(isfinite, get_value(aux.precip_sources.q_liq))
+            @test all(isfinite, get_value(aux.precip_sources.q_ice))
+            @test all(isfinite, get_value(aux.precip_sources.q_rai))
+            @test all(isfinite, get_value(aux.precip_sources.q_sno))
+            @test all(
+                isapprox.(
+                    get_value(aux.precip_sources.q_tot),
+                    -get_value(aux.precip_sources.q_rai) - get_value(aux.precip_sources.q_sno),
+                    rtol = sqrt(eps(FT)),
+                ),
+            )
 
-    CO.precompute_aux_thermo!(nequil_moist_ρdTq, dY, Y, aux, t)
-    @test aux.moisture_variables.ρ == aux.moisture_variables.ρ_dry .+ Y.ρq_tot
-    @test aux.moisture_variables.p == TD.air_pressure.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.θ_liq_ice == TD.liquid_ice_pottemp.(thermo_params, aux.moisture_variables.ts)
-    @test aux.moisture_variables.θ_dry ==
-          TD.dry_pottemp.(thermo_params, aux.moisture_variables.T, aux.moisture_variables.ρ_dry)
-
-    aux = CO.initialise_aux(FT, ip, params..., (; dt = 2.0), 0.0, nequil_moist_ρθq)
-    Y = CO.initialise_state(nequil_moist_ρθq, precip_2m, ip)
-    dY = Y / 10
-
-    CO.precompute_aux_precip!(precip_2m, dY, Y, aux, t)
-    tmp = @. CO.precip_helper_sources!(
-        precip_2m,
-        aux.common_params,
-        aux.thermo_params,
-        aux.air_params,
-        aux.moisture_variables.q_tot,
-        aux.moisture_variables.q_liq,
-        aux.precip_variables.q_rai,
-        aux.precip_variables.N_liq,
-        aux.precip_variables.N_rai,
-        aux.moisture_variables.T,
-        aux.moisture_variables.ρ,
-        aux.TS.dt,
-    )
-
-    @test aux.precip_sources.S_q_rai ≈ tmp.S_q_rai atol = eps(FT) * 10
-    @test aux.precip_sources.S_q_tot ≈ tmp.S_q_tot atol = eps(FT) * 10
-    @test aux.precip_sources.S_q_liq ≈ tmp.S_q_liq atol = eps(FT) * 10
-    @test aux.precip_sources.S_N_liq ≈ tmp.S_N_liq atol = eps(FT) * 10
-    @test aux.precip_sources.S_N_rai ≈ tmp.S_N_rai atol = eps(FT) * 10
+        else
+            @test all(isfinite, get_value(aux.precip_sources.q_tot))
+            @test all(isfinite, get_value(aux.precip_sources.q_liq))
+            @test all(isfinite, get_value(aux.precip_sources.q_rai))
+            @test all(isfinite, get_value(aux.precip_sources.N_aer))
+            @test all(isfinite, get_value(aux.precip_sources.N_liq))
+            @test all(isfinite, get_value(aux.precip_sources.N_rai))
+            @test get_value(aux.precip_sources.q_tot) == -get_value(aux.precip_sources.q_rai)
+        end
+    end
 end


### PR DESCRIPTION
This PR tries to make KiD closer to ClimaAtmos. That means:
- more broadcasting
- fields of tuples

I tried to simplify some of the rhs computations. I'm not fully settled on the state and aux structure, yet. For example whether 2M scheme should carry q_ice and q_sno in the `Y` state. 

Anyway, I think the tests should be passing now and the examples should be running and producing some results. I think there were some examples where the results are different, so I still need to work on the PR. But I think this is a good time to start getting some feedback about it. So I'll be very grateful if you could take a look: @sajjadazimi , @nefrathenrici @edejong-caltech 