### PR TITLE
activate only at cloud base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 [compat]
 ClimaCore = "0.14"
 ClimaCorePlots = "0.2"
-ClimaParams = "0.10.6"
+ClimaParams = "0.10.7"
 CloudMicrophysics = "0.20"
 DiffEqBase = "6"
 Distributions = "0.25"

--- a/src/Common/initial_condition.jl
+++ b/src/Common/initial_condition.jl
@@ -127,8 +127,7 @@ function initial_condition_1d(
     ts = TD.PhaseEquil_ρTq(thermo_params, ρ, T, q_tot)
     p::FT = TD.air_pressure(thermo_params, ts)
 
-    N_aer_0::FT = common_params.prescribed_Nd * ρ_dry / ρ_SDP
-    N_aer::FT = N_aer_0
+    N_aer::FT = common_params.prescribed_Nd * ρ_dry / ρ_SDP
 
     q_liq::FT = FT(0) #TD.liquid_specific_humidity(thermo_params, ts)
     q_ice::FT = FT(0) #TD.ice_specific_humidity(thermo_params, ts)
@@ -173,7 +172,6 @@ function initial_condition_1d(
         N_ice,
         N_rai,
         N_aer,
-        N_aer_0,
         zero,
     )
 end
@@ -221,7 +219,6 @@ function initial_condition(
     num_ratio = SF.gamma_inc(thrshld, k)[2]
     N_liq::FT = num_ratio * Nd
     N_rai::FT = Nd - N_liq
-    N_aer_0::FT = FT(0)
     N_aer::FT = FT(0)
 
     T::FT = FT(300)
@@ -253,7 +250,6 @@ function initial_condition(
         N_liq,
         N_rai,
         N_aer,
-        N_aer_0,
         zero,
     )
 end

--- a/src/Common/ode_utils.jl
+++ b/src/Common/ode_utils.jl
@@ -121,7 +121,12 @@ function initialise_aux(
     end
 
     # Allocate scratch which is a tuple of fields for storing intermediate outputs
-    scratch = (; tmp = similar(ip.q_tot), tmp2 = similar(ip.q_tot), tmp3 = similar(ip.q_tot))
+    scratch = (;
+        tmp = similar(ip.q_tot),
+        tmp2 = similar(ip.q_tot),
+        tmp3 = similar(ip.q_tot),
+        tmp_surface = similar(CC.Fields.level(ip.q_tot, 1), Tuple{FT, FT}),
+    )
 
     # Allocate a tuple of fields for storing precomputed thermodynamic variables
     thermo_variables =
@@ -147,7 +152,6 @@ function initialise_aux(
             N_liq = ip.N_liq,
             N_rai = ip.N_rai,
             N_aer = ip.N_aer,
-            N_aer_0 = ip.N_aer_0,
         )
         velocities = (; term_vel_N_rai = copy(ip.zero), term_vel_rai = copy(ip.zero))
         precip_sources_eltype = @NamedTuple{q_tot::FT, q_liq::FT, q_rai::FT, N_aer::FT, N_liq::FT, N_rai::FT}

--- a/src/K1DModel/tendency.jl
+++ b/src/K1DModel/tendency.jl
@@ -15,10 +15,12 @@ end
 
     (; thermo_params, activation_params, air_params, kid_params) = aux
     (; T, p, ρ) = aux.thermo_variables
-    (; q_tot, q_liq, q_ice, N_aer_0, N_aer) = aux.microph_variables
+    (; q_tot, q_liq, q_ice, N_aer, N_liq) = aux.microph_variables
     (; r_dry, std_dry, κ) = kid_params
     (; ρw) = aux.prescribed_velocity
     (; dt) = aux.TS
+
+    f_interp = CC.Operators.InterpolateF2C()
 
     FT = eltype(thermo_params)
 
@@ -26,37 +28,55 @@ end
     N_act = aux.scratch.tmp2
     S_Nl = aux.scratch.tmp3
 
-    f_interp = CC.Operators.InterpolateF2C()
+    cloud_base_S_Nl_and_z = aux.scratch.tmp_surface
 
     vol_mix_ratio = (FT(1),)
     mass_mix_ratio = (FT(1),)
-    molar_mass = (FT(0.42),) # TODO - molar mass not needed for 1 aerosol type
+    molar_mass = (FT(0.42),) # molar mass not needed for 1 aerosol type
     kappa = (κ,)
 
     S_eltype = eltype(aux.activation_sources)
     to_sources(args...) = S_eltype(tuple(args...))
 
+    # Update N_aer for netcdf output
     @. N_aer = Y.N_aer
 
+    # Compute supersaturation
     @. S_liq = TD.supersaturation(thermo_params, TD.PhasePartition(q_tot, q_liq, q_ice), ρ, T, TD.Liquid())
 
-    @. N_act = first(
-        CMAA.N_activated_per_mode(
-            activation_params,
-            CMAM.AerosolDistribution(
-                CMAM.Mode_κ(r_dry, std_dry, N_aer_0, (vol_mix_ratio,), (mass_mix_ratio,), (molar_mass,), (kappa,)),
-            ),
-            air_params,
-            thermo_params,
-            T,
-            p,
-            f_interp(ρw.components.data.:1) / ρ,
-            TD.PhasePartition(q_tot, q_liq, q_ice),
+    # Total number of activated aerosol particles
+    @. N_act = CMAA.total_N_activated(
+        activation_params,
+        CMAM.AerosolDistribution(
+            CMAM.Mode_κ(r_dry, std_dry, N_aer, (vol_mix_ratio,), (mass_mix_ratio,), (molar_mass,), (kappa,)),
         ),
+        air_params,
+        thermo_params,
+        T,
+        p,
+        f_interp(ρw.components.data.:1) / ρ,
+        TD.PhasePartition(q_tot, q_liq, q_ice),
+    )
+    # Convert the total activated number to tendency
+    @. S_Nl = ifelse(S_liq < 0 || isnan(N_act), FT(0), max(FT(0), N_act - N_liq) / dt)
+
+    # Find S_Nl and z at cloud base:
+    z = CC.Fields.coordinate_field(S_Nl).z # height
+    z_min = minimum(z) # height at first level (only works without topography)
+    CC.Operators.column_mapreduce!(
+        tuple,  # At every point map the input S_Nl and z into a tuple that will be used by reduce
+        ((target_S_Nl_value, target_z_value), (S_Nl_value, z_value)) -> ifelse(
+            target_z_value == z_min && S_Nl_value >= 1e7,
+            (S_Nl_value, z_value),
+            (target_S_Nl_value, target_z_value),
+        ), # reduction function
+        cloud_base_S_Nl_and_z, # destination for output (a field of tuples)
+        S_Nl, # input
+        z, # input
     )
 
-    @. S_Nl = ifelse(S_liq < 0 || isnan(N_act), FT(0), max(FT(0), N_act - (N_aer_0 - Y.N_aer)) / dt)
-
+    # Use the S_Nl tendnecy at cloud base
+    @. S_Nl = ifelse(z == last(cloud_base_S_Nl_and_z), S_Nl, FT(0))
     @. aux.activation_sources = to_sources(-S_Nl, S_Nl)
 end
 
@@ -185,6 +205,10 @@ end
         bottom = CC.Operators.Extrapolate(),
         top = CC.Operators.SetValue(CC.Geometry.WVector(0.0)),
     )
+    ∂ₐ = CC.Operators.DivergenceF2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
+
+    @. dY.N_aer += -∂ₐ((aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ)) * If(Y.N_aer))
+    @. dY.N_liq += -∂((aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ)) * If(Y.N_liq))
 
     @. dY.N_rai +=
         -∂(
@@ -202,6 +226,9 @@ end
         )
 
     fcc = CC.Operators.FluxCorrectionC2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
+    @. dY.N_aer += fcc((aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ)), Y.N_aer)
+    @. dY.N_liq += fcc((aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ)), Y.N_liq)
+
     @. dY.N_rai += fcc(
         (
             aux.prescribed_velocity.ρw / If(aux.thermo_variables.ρ) +

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -27,7 +27,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 [compat]
 ClimaCore = "0.14"
 ClimaCorePlots = "0.2"
-ClimaParams = "0.10.6"
+ClimaParams = "0.10.7"
 CloudMicrophysics = "0.20"
 DiffEqBase = "6.75"
 NCDatasets = "0.14"

--- a/test/unit_tests/k1d_unit_test.jl
+++ b/test/unit_tests/k1d_unit_test.jl
@@ -23,25 +23,40 @@ end
 
 @testset "Initialise aux" begin
 
-    ip = (;
-        ρ = [1.0, 1.0],
-        ρ_dry = [0.999, 1.0],
-        θ_liq_ice = [440.0, 450.0],
-        q_tot = [1e-3, 0.0],
-        q_liq = [0.0, 0.0],
-        q_ice = [0.0, 0.0],
-        p = [101300.0, 90000.0],
-        T = [300.0, 290.0],
-        θ_dry = [440.0, 450],
-        q_rai = [0.0, 0.0],
-        q_sno = [0.0, 0.0],
-        N_liq = [0.0, 0.0],
-        N_rai = [0.0, 0.0],
-        N_aer_0 = [0.0, 0.0],
-        N_aer = [0.0, 0.0],
-        zero = [0.0, 0.0],
+    _ip = (;
+        ρ = 1.2,
+        ρ_dry = 1.185,
+        θ_liq_ice = 350.0,
+        q_tot = 15e-3 / 1.2,
+        q_liq = 1e-3 / 1.2,
+        q_ice = 2e-3 / 1.2,
+        q_rai = 1e-3 / 1.2,
+        q_sno = 2e-3 / 1.2,
+        ρq_tot = 15e-3,
+        ρq_liq = 1e-3,
+        ρq_ice = 2e-3,
+        ρq_rai = 1e-3,
+        ρq_sno = 2e-3,
+        p = 101300.0,
+        T = 280.0,
+        θ_dry = 360.0,
+        N_liq = 1e8,
+        N_ice = 1e8,
+        N_rai = 1e4,
+        N_sno = 1e4,
+        N_aer = 5e7,
+        zero = 0.0,
     )
-    space, face_space = K1D.make_function_space(FT, 0, 100, 10)
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint{FT}(0),
+        CC.Geometry.ZPoint{FT}(1),
+        boundary_names = (:bottom, :top),
+    )
+    mesh = CC.Meshes.IntervalMesh(domain, nelems = 1)
+    space = CC.Spaces.CenterFiniteDifferenceSpace(mesh)
+    face_space = CC.Spaces.FaceFiniteDifferenceSpace(mesh)
+    coord = CC.Fields.coordinate_field(space)
+    ip = map(coord -> _ip, coord)
 
     @test_throws Exception K1D.initialise_aux(FT, ip, params..., 0.0, 0.0, face_space, no_precip)
     @test_throws Exception K1D.initialise_aux(FT, ip, params..., 0.0, 0.0, face_space, CO.EquilibriumMoisture())
@@ -116,7 +131,6 @@ end
         N_rai = 1e4,
         N_sno = 1e4,
         N_aer = 5e7,
-        N_aer_0 = 1e8,
         zero = 0.0,
     )
     domain = CC.Domains.IntervalDomain(

--- a/test/unit_tests/k2d_unit_test.jl
+++ b/test/unit_tests/k2d_unit_test.jl
@@ -12,31 +12,19 @@ end
 
 @testset "Initialise aux" begin
 
-    ip = (;
-        ρ = [1.0, 1.0],
-        ρ_dry = [0.999, 1.0],
-        θ_liq_ice = [440.0, 450.0],
-        q_tot = [1e-3, 0.0],
-        q_liq = [0.0, 0.0],
-        q_ice = [0.0, 0.0],
-        p = [101300.0, 90000.0],
-        T = [300.0, 290.0],
-        θ_dry = [440.0, 450],
-        q_rai = [0.0, 0.0],
-        q_sno = [0.0, 0.0],
-        N_liq = [0.0, 0.0],
-        N_rai = [0.0, 0.0],
-        N_aer_0 = [0.0, 0.0],
-        N_aer = [0.0, 0.0],
-        zero = [0.0, 0.0],
-    )
     space, face_space = K2D.make_function_space(FT)
+    coords = CC.Fields.coordinate_field(space)
+    face_coords = CC.Fields.coordinate_field(face_space)
+    ρ_profile = CO.ρ_ivp(FT, kid_params, thermo_params)
+    init =
+        map(coord -> CO.initial_condition_1d(FT, common_params, kid_params, thermo_params, ρ_profile, coord.z), coords)
+    t = 1.1 * kid_params.t1
 
-    @test_throws Exception K2D.initialise_aux(FT, ip, params..., 0.0, 0.0, face_space, no_precip)
-    @test_throws Exception K2D.initialise_aux(FT, ip, params..., 0.0, 0.0, face_space, K1D.EquilibriumMoisture())
-    @test_throws Exception K2D.initialise_aux(FT, ip, params..., 0.0, 0.0, face_space, K1D.NonEquilibriumMoisture())
+    @test_throws Exception K2D.initialise_aux(FT, init, params..., 0.0, 0.0, face_space, no_precip)
+    @test_throws Exception K2D.initialise_aux(FT, init, params..., 0.0, 0.0, face_space, K1D.EquilibriumMoisture())
+    @test_throws Exception K2D.initialise_aux(FT, init, params..., 0.0, 0.0, face_space, K1D.NonEquilibriumMoisture())
 
-    aux = K2D.initialise_aux(FT, ip, params..., 100.0, 200.0, 0.0, 0.0, space, face_space, equil_moist_ρθq, precip_1m)
+    aux = K2D.initialise_aux(FT, init, params..., 100.0, 200.0, 0.0, 0.0, space, face_space, equil_moist_ρθq, precip_1m)
     @test aux isa NamedTuple
     @test aux.cloud_sources == nothing
     @test LA.norm(aux.precip_sources) == 0


### PR DESCRIPTION
Here is my attempt at activating only at cloud base and then advecting things up. I added advection of both aerosol and cloud droplets.

Things to fix:
- bc at the top
- threshold used to define what is cloud base. - right now I have S_Nl = 1e7 but ofc thats not very general

Her is an example 2-moment microphysics plot with it:

![timeheight](https://github.com/CliMA/KinematicDriver.jl/assets/1196696/6cc2c8f8-00f7-40c1-95c3-045594ad7b6d)
