### PR TITLE
Different calibration time-ranges depending on test case

### DIFF
--- a/src/CalibrateCMP/CalibrateCMP.jl
+++ b/src/CalibrateCMP/CalibrateCMP.jl
@@ -12,7 +12,6 @@ using Interpolations
 using Optim
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
-using EnsembleKalmanProcesses.Observations
 using JLD2
 
 const EKP = EnsembleKalmanProcesses

--- a/src/CalibrateCMP/KiDUtils.jl
+++ b/src/CalibrateCMP/KiDUtils.jl
@@ -43,6 +43,16 @@ function run_KiD_multiple_cases(u::Array{FT, 1}, u_names::Array{String, 1}, conf
         config["model"]["w1"] = case.w1
         config["model"]["p0"] = case.p0
         config["model"]["Nd"] = case.Nd
+        if "t_cal" in collect(keys(case))
+            config["model"]["filter"] = make_filter_props(
+                config["model"]["filter"]["nz_unfiltered"],
+                case.t_cal;
+                apply = config["model"]["filter"]["apply"],
+                nz_per_filtered_cell = config["model"]["filter"]["nz_per_filtered_cell"],
+                nt_per_filtered_cell = config["model"]["filter"]["nt_per_filtered_cell"],
+            )
+        end
+
         ode_sol, aux, precip = run_KiD(u, u_names, config["model"])
         single_case_Gvector =
             config["model"]["filter"]["apply"] ?

--- a/src/CalibrateCMP/ReferenceModels.jl
+++ b/src/CalibrateCMP/ReferenceModels.jl
@@ -40,6 +40,10 @@ function get_obs_matrix(
     _data_matrix = Matrix{FT}
     for (i, case) in enumerate(cases)
         _dir::String = case.dir
+
+        if "t_cal" in collect(keys(case))
+            times = case.t_cal
+        end
         _data_matrix_single_case::Matrix{FT} =
             get_obs_matrix(_dir, variables, heights, times; apply_filter = apply_filter)
 

--- a/test/experiments/calibrations/config.jl
+++ b/test/experiments/calibrations/config.jl
@@ -77,7 +77,8 @@ function get_observations_config()
     config["true_values_offset"] = 0.25
     # Define data
     root_dir = "/Users/sajjadazimi/Postdoc/Results/01-PySDM_1D_rain_shaft/data/03-p1000/"
-    config["cases"] = [(w1 = 3.0, p0 = 100000.0, Nd = 100 * 1e6, dir = root_dir * "rhow=3.0_Nd=100/")]
+    config["cases"] =
+        [(w1 = 3.0, p0 = 100000.0, Nd = 100 * 1e6, t_cal = 0.0:600.0:3600.0, dir = root_dir * "rhow=3.0_Nd=100/")]
     # Define type of data
     config["data_type"] = Float64
     return config

--- a/test/unit_tests/calibration_pipeline/run_calibration_pipeline_unit_tests.jl
+++ b/test/unit_tests/calibration_pipeline/run_calibration_pipeline_unit_tests.jl
@@ -1,6 +1,5 @@
 using Statistics, LinearAlgebra, Random, Optim
 using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.Observations
 using EnsembleKalmanProcesses.ParameterDistributions
 
 import KinematicDriver


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Allow different time ranges for calibration, depending on the specific test case. With this modifications we should be able to choose, for each PySDM test case, the `initial time`, `dt`, and `final time` for performing the calibrations.
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
