### PR TITLE
Calibration feature to select different maximum and minimum height depending on the variable

### DIFF
--- a/src/CalibrateCMP/HelperFuncs.jl
+++ b/src/CalibrateCMP/HelperFuncs.jl
@@ -18,6 +18,8 @@ end
 
 function make_filter_props(
     n_z,
+    z_min,
+    z_max,
     t_calib;
     apply = false,
     nz_per_filtered_cell = ones(Int, length(n_z)),
@@ -28,6 +30,8 @@ function make_filter_props(
 
     filter = Dict()
     filter["apply"] = apply
+    filter["z_min"] = z_min
+    filter["z_max"] = z_max
     filter["nz_per_filtered_cell"] = nz_per_filtered_cell
     filter["nt_per_filtered_cell"] = nt_per_filtered_cell
     filter["nz_unfiltered"] = n_z
@@ -55,6 +59,14 @@ function get_numbers_from_config(config::Dict)
 
     @assert length(n_heights) == length(config["observations"]["data_names"])
     return (; n_cases, n_heights, n_times)
+end
+
+function get_z_bounds_from_config(config::Dict)
+
+    _z_min = config["model"]["filter"]["z_min"]
+    _z_max = config["model"]["filter"]["z_max"]
+
+    return (; _z_min, _z_max)
 end
 
 function get_case_i_vec(vec::Vector{FT}, i::Int, n_single_case::Int) where {FT <: Real}

--- a/src/CalibrateCMP/ReferenceModels.jl
+++ b/src/CalibrateCMP/ReferenceModels.jl
@@ -8,8 +8,7 @@ function get_obs!(config::Dict)
         _z_min = FT(0)
         _z_max = FT(1)
     else
-        _z_min = config["model"]["z_min"]
-        _z_max = config["model"]["z_max"]
+        _z_min, _z_max = get_z_bounds_from_config(config)
     end
     _dz = (_z_max - _z_min) ./ _n_heights
     _heights::Vector{Vector{FT}} = collect.(range.(_z_min .+ _dz ./ 2, _z_max .- _dz ./ 2, _n_heights))

--- a/test/experiments/calibrations/config.jl
+++ b/test/experiments/calibrations/config.jl
@@ -129,6 +129,8 @@ function get_model_config()
     config["κ"] = 0.9
     config["filter"] = KCP.make_filter_props(
         [config["n_elem"], config["n_elem"], 1], # nz (for each variable)
+        [config["z_min"], config["z_min"], config["z_min"]], # z_min (for each variable)
+        [config["z_max"], config["z_max"], config["z_max"]], # z_max (for each variable)
         config["t_calib"];
         apply = true,
         nz_per_filtered_cell = [4, 4, 1],


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
With this PR we will be able to differentiate, for each variable used for calibrations, the values of `z_min` and `z_max`. 
As a result, we can be more specific regarding the depth layer of each variable and focus on the regions in which they are most informative. 
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
