### PR TITLE
Update climacommon to 2025_03_18

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ env:
 agents:
   queue: new-central
   slurm_ntasks: 1
-  modules: climacommon/2024_05_27
+  modules: climacommon/2025_03_18
 
 steps:
   - label: "Init environment :computer:"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.4.

This version is needed to use CUDA 5.7, so I would recommend updating.