### PR TITLE
fix: z_max cannot be greater than z_2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,7 +100,7 @@ steps:
         artifact_paths: "test/experiments/KiD_driver/Output_NonEquilibriumMoisture_Precipitation2M_SB2006_Chen2022/figures/*"
 
       - label: ":snowman: Experiments: non equil + 1M with ice and snow"
-        command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=NonEquilibriumMoisture --precipitation_choice=Precipitation1M --rv_0 0.0008 --rv_1 0.0008 --rv_2 0.0001 --tht_0 260 --tht_1 260 --tht_2 270 --w1 2 --z_max 4000 --n_elem 200"
+        command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=NonEquilibriumMoisture --precipitation_choice=Precipitation1M --rv_0 0.0008 --rv_1 0.0008 --rv_2 0.0001 --tht_0 260 --tht_1 260 --tht_2 270 --w1 2 --z_max 4000 --z_2 4000 --n_elem 200"
         artifact_paths: "test/experiments/KiD_driver/Output_NonEquilibriumMoisture_Precipitation1M_CliMA_1M/figures/*"
 
       - label: ":crystal_ball: Experiments: Box model"

--- a/test/experiments/KiD_driver/run_KiD_simulation.jl
+++ b/test/experiments/KiD_driver/run_KiD_simulation.jl
@@ -11,6 +11,9 @@ include(joinpath(pkgdir(KinematicDriver), "test", "create_parameters.jl"))
 include(joinpath(pkgdir(KinematicDriver), "test", "plotting_utils.jl"))
 
 function run_KiD_simulation(::Type{FT}, opts) where {FT}
+    if opts["z_2"] < opts["z_max"]
+        throw(ArgumentError("z_max cannot be higher than z_2"))
+    end
 
     # Equations to solve for mositure and precipitation variables
     moisture_choice = opts["moisture_choice"]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

For whatever reason, running with `Float32` exposes an instability plotting density if `z_max` > `z_2`,  see figure:
<img width="1173" height="1152" alt="image" src="https://github.com/user-attachments/assets/021c681e-22a5-4d5d-8d8e-e138386b2ff8" />

Instead of diving deeper into this, this PR enforces `z_max = z_2` in the `KiD` driver.

<details> <summary> dirty code to make plots </summary>

code to be run after (locally) calling all code in `run_KiD_simulation.jl` up until `ρ_profile = CO.ρ_ivp(FT, kid_params, thermo_params)`

```Julia
FT = Float64
    # z2
    default_toml_dict = CP.create_toml_dict(FT)
    toml_dict = override_toml_dict(path, default_toml_dict, w1 = FT(opts["w1"]), t1 = FT(opts["t1"]), p0 = FT(opts["p0"]), z_0 = FT(opts["z_0"]), z_1 = FT(opts["z_1"]), 
        z_2 = FT(opts["z_2"]), 
        # z_2 = FT(opts["z_max"]), 
        rv_0 = FT(opts["rv_0"]), rv_1 = FT(opts["rv_1"]), rv_2 = FT(opts["rv_2"]), tht_0 = FT(opts["tht_0"]), tht_1 = FT(opts["tht_1"]), tht_2 = FT(opts["tht_2"]), precip_sources = Int(opts["precip_sources"]), precip_sinks = Int(opts["precip_sinks"]), qtot_flux_correction = Int(opts["qtot_flux_correction"]), prescribed_Nd = FT(opts["prescribed_Nd"]), open_system_activation = Int(opts["open_system_activation"]), r_dry = FT(opts["r_dry"]), std_dry = FT(opts["std_dry"]), κ = FT(opts["kappa"]))
    common_params = create_common_parameters(toml_dict)
    kid_params = create_kid_parameters(toml_dict)
    space, face_space = K1D.make_function_space(FT, FT(opts["z_min"]), FT(opts["z_max"]), opts["n_elem"])
    coord = CC.Fields.coordinate_field(space)
    ρ_profile_z2 = CO.ρ_ivp(FT, kid_params, thermo_params)
    # ρ_profile.(coord.z)
    dry = false
    init_z2(z) = CO.init_profile(FT, kid_params, thermo_params, z; dry)
    init_sfc_z2 = init_z2(0.0)

    toml_dict = override_toml_dict(path, default_toml_dict, w1 = FT(opts["w1"]), t1 = FT(opts["t1"]), p0 = FT(opts["p0"]), z_0 = FT(opts["z_0"]), z_1 = FT(opts["z_1"]), 
        # z_2 = FT(opts["z_2"]), 
        z_2 = FT(opts["z_max"]), 
        rv_0 = FT(opts["rv_0"]), rv_1 = FT(opts["rv_1"]), rv_2 = FT(opts["rv_2"]), tht_0 = FT(opts["tht_0"]), tht_1 = FT(opts["tht_1"]), tht_2 = FT(opts["tht_2"]), precip_sources = Int(opts["precip_sources"]), precip_sinks = Int(opts["precip_sinks"]), qtot_flux_correction = Int(opts["qtot_flux_correction"]), prescribed_Nd = FT(opts["prescribed_Nd"]), open_system_activation = Int(opts["open_system_activation"]), r_dry = FT(opts["r_dry"]), std_dry = FT(opts["std_dry"]), κ = FT(opts["kappa"]))
    common_params = create_common_parameters(toml_dict)
    kid_params = create_kid_parameters(toml_dict)
    space, face_space = K1D.make_function_space(FT, FT(opts["z_min"]), FT(opts["z_max"]), opts["n_elem"])
    coord = CC.Fields.coordinate_field(space)
    ρ_profile_zmax = CO.ρ_ivp(FT, kid_params, thermo_params)

    init_zmax(z) = CO.init_profile(FT, kid_params, thermo_params, z; dry)
    init_sfc_zmax = init_zmax(0.0)

    z = vec(coord.z)
    
    fig = Figure(); 
    # qv
    ax = Axis(fig[1, 1])
    scatterlines!(getfield.(init_z2.(z), :qv), z, label = "qv, z_2")
    scatterlines!(getfield.(init_zmax.(z), :qv), z, label = "qv, z_max")
    hlines!(ax, [opts["z_0"], opts["z_1"], opts["z_2"]], color = :black, linestyle = :dash)
    axislegend(ax)
    # θ_std
    ax = Axis(fig[1, 2])
    scatterlines!(getfield.(init_z2.(z), :θ_std), z, label = "θ_std, z_2")
    scatterlines!(getfield.(init_zmax.(z), :θ_std), z, label = "θ_std, z_max")
    hlines!(ax, [opts["z_0"], opts["z_1"], opts["z_2"]], color = :black, linestyle = :dash)
    axislegend(ax)
    # ρ_0
    ax = Axis(fig[1, 3])
    scatterlines!(getfield.(init_z2.(z), :ρ_0), z, label = "ρ_0, z_2")
    scatterlines!(getfield.(init_zmax.(z), :ρ_0), z, label = "ρ_0, z_max")
    hlines!(ax, [opts["z_0"], opts["z_1"], opts["z_2"]], color = :black, linestyle = :dash)
    axislegend(ax)
    fig

    fig = Figure()
    ax = Axis(fig[1, 1])
    scatterlines!(parent(ρ_profile_zmax.(coord.z))|>vec, parent(coord.z)|>vec, label = "z_max")
    scatterlines!(parent(ρ_profile_z2.(coord.z))|>vec, parent(coord.z)|>vec, label = "z_2")
    scatterlines!((parent(ρ_profile_z2.(coord.z))|>vec) .- (parent(ρ_profile_zmax.(coord.z))|>vec), parent(coord.z)|>vec, label = "z_2 - z_max")
    hlines!(ax, [opts["z_0"], opts["z_1"], opts["z_2"]], color = :black, linestyle = :dash)
    axislegend(ax)
    fig
```

</details>


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
