### PR TITLE
rft: improve error handling

### DIFF
--- a/src/Common/ode_utils.jl
+++ b/src/Common/ode_utils.jl
@@ -21,7 +21,7 @@ end
     on different moisture and precipitation types
 """
 function initialise_state(sm::AbstractMoistureStyle, sp::AbstractPrecipitationStyle, initial_profiles)
-    error("initailisation not implemented for a given $sm and $sp")
+    error("initailisation not implemented for a given $(typeof(sm).name.name) and $(typeof(sp).name.name)")
 end
 function initialise_state(::EquilibriumMoisture, ::Union{NoPrecipitation, Precipitation0M}, initial_profiles)
     return CC.Fields.FieldVector(; ρq_tot = initial_profiles.ρq_tot)

--- a/src/Common/tendency.jl
+++ b/src/Common/tendency.jl
@@ -732,7 +732,9 @@ end
 
 
 @inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ps::AbstractPrecipitationStyle, dY, Y, aux, t)
-    error("sources_tendency not implemented for a given $sp")
+    error(
+        "precip_sources_tendency! not implemented for the given pair $(typeof(ms).name.name) and $(typeof(ps).name.name)",
+    )
 end
 @inline function precip_sources_tendency!(ms::AbstractMoistureStyle, ::NoPrecipitation, dY, Y, aux, t) end
 


### PR DESCRIPTION
- only show name of struct in error message

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
