### PR TITLE
rft(rm): unused `path` arg in `override_toml_dict`

### DIFF
--- a/test/experiments/Ki2D_driver/run_kinematic2d_simulations.jl
+++ b/test/experiments/Ki2D_driver/run_kinematic2d_simulations.jl
@@ -34,8 +34,7 @@ function run_K2D_simulation(::Type{FT}, opts) where {FT}
     # Overwrite the defaults parameters based on options
     default_toml_dict = CP.create_toml_dict(FT)
     toml_dict = override_toml_dict(
-        path,
-        default_toml_dict,
+        default_toml_dict;
         w1 = FT(opts["w1"]),
         t1 = FT(opts["t1"]),
         p0 = FT(opts["p0"]),

--- a/test/experiments/KiD_col_sed_driver/run_KiD_col_sed_simulation.jl
+++ b/test/experiments/KiD_col_sed_driver/run_KiD_col_sed_simulation.jl
@@ -33,8 +33,7 @@ function run_KiD_col_sed_simulation(::Type{FT}, opts) where {FT}
     # Overwrite the defaults parameters based on options
     default_toml_dict = CP.create_toml_dict(FT)
     toml_dict = override_toml_dict(
-        path,
-        default_toml_dict,
+        default_toml_dict;
         precip_sources = 1,
         precip_sinks = 0,
         prescribed_Nd = FT(opts["prescribed_Nd"]),

--- a/test/experiments/KiD_driver/run_KiD_simulation.jl
+++ b/test/experiments/KiD_driver/run_KiD_simulation.jl
@@ -50,8 +50,7 @@ function run_KiD_simulation(::Type{FT}, opts) where {FT}
     # Overwrite the defaults parameters based on options
     default_toml_dict = CP.create_toml_dict(FT)
     toml_dict = override_toml_dict(
-        path,
-        default_toml_dict,
+        default_toml_dict;
         w1 = FT(opts["w1"]),
         t1 = FT(opts["t1"]),
         p0 = FT(opts["p0"]),

--- a/test/experiments/box_driver/run_box_simulation.jl
+++ b/test/experiments/box_driver/run_box_simulation.jl
@@ -26,8 +26,7 @@ function run_box_simulation(::Type{FT}, opts) where {FT}
     # Overwrite the defaults parameters based on options
     default_toml_dict = CP.create_toml_dict(FT)
     toml_dict = override_toml_dict(
-        path,
-        default_toml_dict,
+        default_toml_dict;
         precip_sources = 1,
         precip_sinks = 0,
         prescribed_Nd = FT(opts["Nd"]),

--- a/test/initial_condition_tests/initial_profile_test.jl
+++ b/test/initial_condition_tests/initial_profile_test.jl
@@ -23,7 +23,7 @@ const FT = Float64
 
 # Create parameters overwrite the defaults to match PySDM
 default_toml_dict = CP.create_toml_dict(FT)
-toml_dict = override_toml_dict(@__DIR__, default_toml_dict)
+toml_dict = override_toml_dict(default_toml_dict)
 thermo_params = create_thermodynamics_parameters(toml_dict)
 common_params = create_common_parameters(toml_dict)
 kid_params = create_kid_parameters(toml_dict)

--- a/test/opt_tests/opt_tests.jl
+++ b/test/opt_tests/opt_tests.jl
@@ -19,7 +19,7 @@ function get_tendency_function_arguments(::Type{FT}, moisture_choice, precipitat
 
     # setup
     default_toml_dict = CP.create_toml_dict(FT)
-    toml_dict = override_toml_dict("_", default_toml_dict)
+    toml_dict = override_toml_dict(default_toml_dict)
     common_params = create_common_parameters(toml_dict)
     kid_params = create_kid_parameters(toml_dict)
     thermo_params = create_thermodynamics_parameters(toml_dict)

--- a/test/unit_tests/unit_test.jl
+++ b/test/unit_tests/unit_test.jl
@@ -22,7 +22,7 @@ include(joinpath(kid_dir, "test", "create_parameters.jl"))
 
 # override the defaults
 default_toml_dict = CP.create_toml_dict(FT)
-toml_dict = override_toml_dict(@__DIR__, default_toml_dict)
+toml_dict = override_toml_dict(default_toml_dict)
 
 # create all the parameters structs ...
 common_params = create_common_parameters(toml_dict)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR removes an unused argument from the `override_toml_dict` function in `test/create_parameters.jl`.

Additional changes in the file is due to allowing julia formatting to be applied.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
