### PR TITLE
rft: simplify field initialization

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v4
         with:
-          version: '2' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
+          version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
           suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs

--- a/src/Common/tendency.jl
+++ b/src/Common/tendency.jl
@@ -23,7 +23,7 @@ end
     Zero out previous timestep tendencies
 """
 @inline function zero_tendencies!(dY)
-    @. dY = 0
+    @. dY = zero(dY)
 end
 
 """

--- a/test/experiments/KiD_col_sed_driver/run_KiD_col_sed_simulation.jl
+++ b/test/experiments/KiD_col_sed_driver/run_KiD_col_sed_simulation.jl
@@ -83,30 +83,15 @@ function run_KiD_col_sed_simulation(::Type{FT}, opts) where {FT}
     )
 
     # Create the initial condition profiles
+    ic_0d = CO.initial_condition_0d(FT, thermo_params, opts["qt"], opts["prescribed_Nd"], opts["k"], opts["rhod"])
     if precipitation_choice == "CloudyPrecip"
         cloudy_disttypes = determine_cloudy_disttypes(opts["num_moments"])
         cloudy_params, cloudy_pdists = create_cloudy_parameters(FT, cloudy_disttypes)
-        init = map(
-            coord -> CO.cloudy_initial_condition(
-                cloudy_pdists,
-                CO.initial_condition_0d(FT, thermo_params, opts["qt"], opts["prescribed_Nd"], opts["k"], opts["rhod"]),
-                opts["k"],
-            ),
-            coord,
-        )
+        ic_cloudy = CO.cloudy_initial_condition(cloudy_pdists, ic_0d, opts["k"])
+        init = map(Returns(ic_cloudy), coord)
     else
         cloudy_params = nothing
-        init = map(
-            coord -> CO.initial_condition_0d(
-                FT,
-                thermo_params,
-                opts["qt"],
-                opts["prescribed_Nd"],
-                opts["k"],
-                opts["rhod"],
-            ),
-            coord,
-        )
+        init = map(Returns(ic_0d), coord)
     end
 
     # Create aux vector and apply initial condition

--- a/test/unit_tests/unit_test.jl
+++ b/test/unit_tests/unit_test.jl
@@ -15,9 +15,9 @@ import KinematicDriver.K1DModel as K1D
 import KinematicDriver.K2DModel as K2D
 import CloudMicrophysics.Parameters as CMP
 
-const FT = Float64
+FT = Float64
 
-const kid_dir = pkgdir(KinematicDriver)
+kid_dir = pkgdir(KinematicDriver)
 include(joinpath(kid_dir, "test", "create_parameters.jl"))
 
 # override the defaults
@@ -61,11 +61,14 @@ precip_1m = CO.Precipitation1M(
 precip_2m = CO.Precipitation2M(CMP.SB2006(toml_dict), CMP.SB2006VelType(toml_dict))
 precip_p3 = CO.PrecipitationP3(p3, Chen2022, CMP.SB2006(toml_dict), p3_boundary_condition)
 
-# common unit tests
-include("./common_unit_test.jl")
+TT.@testset "unit tests" begin
+    # common unit tests
+    include("./common_unit_test.jl")
 
-# KinematricDriver 1D unit tests
-include("./k1d_unit_test.jl")
+    # KinematricDriver 1D unit tests
+    include("./k1d_unit_test.jl")
 
-# KinematricDriver 2D unit tests
-include("./k2d_unit_test.jl")
+    # KinematricDriver 2D unit tests
+    include("./k2d_unit_test.jl")
+end
+nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

This PR simplifies field initialization.

## Part 1: State initialization

For `initialise_state`, the model state is now a `Field` instead of a `FieldVector`. I made this change upon Dennis' suggestion, because all our state variables live on the same physical space. Only if we had variables on distinct spaces (e.g. face space & center space) would we need a `FieldVector`.

To construct a state, you now simply have to specify the subset of variables from `initial_profiles` (which is a `Field`) that you need. For example:
```julia
function initialise_state(::EquilibriumMoisture, ::Precipitation1M, initial_profiles)
    return NamedTuple{(:ρq_tot, :ρq_rai, :ρq_sno)}.(initial_profiles)
end
```
Notice that the tuple of variable names is in curly braces `NamedTuple{ ( ... ) }`, so the code is type stable.

A nice consequence of this change is that printing the state goes from:
```
1-blocked 768-element ClimaCore.Fields.FieldVector{Float64, @NamedTuple{ρq_tot::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, 128, Matrix{Float64}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 128, Matrix{Float64}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 129, Matrix{Float64}}}, ClimaCore.Grids.CellCenter}}, ρq_rai::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, 128, Matrix{Float64}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 128, Matrix{Float64}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 129, Matrix{Float64}}}, ClimaCore.Grids.CellCenter}}, ρq_sno::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, 128, Matrix{Float64}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 128, Matrix{Float64}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 129, Matrix{Float64}}}, ClimaCore.Grids.CellCenter}}, N_liq::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, 128, Matrix{Float64}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 128, Matrix{Float64}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 129, Matrix{Float64}}}, ClimaCore.Grids.CellCenter}}, N_rai::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, 128, Matrix{Float64}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 128, Matrix{Float64}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 129, Matrix{Float64}}}, ClimaCore.Grids.CellCenter}}, N_aer::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, 128, Matrix{Float64}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 128, Matrix{Float64}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}, ClimaCore.Geometry.AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float64, 1}}}, 129, Matrix{Float64}}}, ClimaCore.Grids.CellCenter}}}}:
 0.017120124428883676
 0.01709942537945516 
 0.01707746256916229 
 0.01705698072705995 
 0.017033711071945134
 0.017015379796717963
 0.01699166980240644 
 0.016973142223766672
 0.01694769220628602 
 0.016929745343594427
 0.01690814076109159 
 0.016887175802276767
 ⋮
 8.0347337840852e7   
 8.024678603174411e7 
 8.014636833599101e7 
 8.004608412490468e7 
 7.994594117001717e7 
 7.984597279684334e7 
 7.974628550453316e7 
 7.964720638438343e7 
 7.954972296377222e7 
 7.945681154290335e7 
 7.937743552950017e7 
 7.933858033168654e7 
```
to
```
@NamedTuple{ρq_tot::Float64, ρq_liq::Float64, ρq_rai::Float64, N_liq::Float64, N_rai::Float64, N_aer::Float64, ρq_ice::Float64, N_ice::Float64, ρq_rim::Float64, B_rim::Float64, ρq_sno::Float64}-valued Field:
  ρq_tot: [0.00106971, 0.0010677, 0.00106569, 0.00106369, 0.00106169, 0.00105969, 0.0010577, 0.0010557, 0.00105371, 0.00105172  …  0.000129366, 0.000125164, 0.000120979, 0.00011681, 0.000112658, 0.000108523, 0.000104404, 0.000100302, 9.62164e-5, 9.21471e-5]
  ρq_liq: [0.0, 0.0, 0.0, 0.0, 4.43212e-105, 2.24717e-100, 6.37915e-96, 1.22312e-91, 1.70167e-87, 1.81417e-83  …  7.6715e-27, 2.76345e-29, 8.81767e-32, 2.4988e-34, 6.29726e-37, 1.41146e-39, 2.81098e-42, 4.96388e-45, 7.74878e-48, 2.5908e-48]
  ρq_rai: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.26324e-105, 2.94174e-98, 2.12927e-93, 1.98241e-87  …  2.2318e-34, 6.23692e-37, 1.50919e-39, 3.17637e-42, 5.85638e-45, 9.57295e-48, 1.4108e-50, 1.90485e-53, 2.3656e-56, 2.65741e-59]
  N_liq: [0.0, 0.0, 0.0, 0.0, 0.0, 2.59188e-93, 1.44687e-88, 3.98972e-84, -7.03503e-79, -3.02458e-74  …  2.13868e-18, 7.22784e-21, 2.1696e-23, 5.76358e-26, 1.35581e-28, 2.82174e-31, 5.18402e-34, 8.37703e-37, 1.18465e-39, 1.45822e-42]
  N_rai: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.09257e-88, 4.68682e-81, 2.02209e-76, 2.40773e-71  …  3.71404e-24, 1.69794e-26, 6.72463e-29, 2.28702e-31, 6.66217e-34, 1.65578e-36, 3.51966e-39, 6.44784e-42, 1.01233e-44, 1.3556e-47]
  N_aer: [1.0915e8, 1.08949e8, 1.08744e8, 1.0854e8, 1.08336e8, 1.08132e8, 1.07928e8, 1.07725e8, 1.07521e8, 1.07318e8  …  7.49398e7, 7.47845e7, 7.46295e7, 7.44747e7, 7.43202e7, 7.41659e7, 7.40118e7, 7.3858e7, 7.37044e7, 7.35554e7]
  ρq_ice: [0.0, 0.0, 0.0, 0.0, 4.26323e-105, 2.16156e-100, 6.13615e-96, 1.17654e-91, 1.63687e-87, 1.7451e-83  …  9.39695e-26, 3.38519e-28, 1.08021e-30, 3.0613e-33, 7.71512e-36, 1.72932e-38, 3.44413e-41, 6.08212e-44, 9.49464e-47, 3.17453e-47]
  N_ice: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
  ρq_rim: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
  B_rim: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
  ρq_sno: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

The only additional change required for the code to run was in `zero_tendencies!`, which now reads
```Julia
@inline function zero_tendencies!(dY)
    @. dY = zero(dY)
end
```
instead of `@. dY = 0`.

The changes to the tests in `unit_tests/` reflect the state no longer being a "vector".

## Part 2: Aux initialization

I introduced a small helper in `initialize_aux`:
```julia
zero_nt(zero, ::Type{NT}) where {NT} = NT(ntuple(Returns(zero), Val(fieldcount(NT))))
zero_nt(::Type{NT}) where {NT} = @. zero_nt(ip.zero, NT)
```
which basically just constructs a `NamedTuple-valued Field` (i.e., like the state, above) of zeros. As above, simply pass a `NamedTuple{ ( ... ) }` with the variable names in a tuple in the curly braces, e.g. 
```julia
cloud_sources = zero_nt(NamedTuple{(:q_liq, :q_ice)})
```

The code is also lightly reorganized to make use of the `merge` function from Base Julia, which let's us construct larger `NamedTuple-valued Field`s from multiple smaller ones.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
