### PR TITLE
fix: rain number adjustment bug

### DIFF
--- a/src/Common/tendency.jl
+++ b/src/Common/tendency.jl
@@ -626,7 +626,7 @@ end
         @. S₁ = triangle(CM2.number_increase_for_mass_limit(numadj, pdf_r.xr_max, q_rai, ρ, N_rai), N_aer)
         @. S₂ = -triangle(-CM2.number_decrease_for_mass_limit(numadj, pdf_r.xr_min, q_rai, ρ, N_rai), N_rai)
         @. aux.precip_sources.N_aer += -1 * !common_params.open_system_activation * (S₁ + S₂)
-        @. aux.precip_sources.N_liq += S₁ + S₂
+        @. aux.precip_sources.N_rai += S₁ + S₂
     end
 
     if Bool(common_params.precip_sinks)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

This pull request makes a targeted fix to the precipitation source calculations in the `src/Common/tendency.jl` file. The change corrects which precipitation category is updated, ensuring that rain (`N_rai`) is incremented instead of liquid (`N_liq`).

Precipitation source calculation correction:

* Updated the accumulation of precipitation sources so that `aux.precip_sources.N_rai` is incremented by `S₁ + S₂` instead of `aux.precip_sources.N_liq`, ensuring the correct category is modified.
